### PR TITLE
chore: configure initial release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,1 @@
 # Changelog
-
-Notable changes are collected here by Release Please.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "initial-version": "0.1.0",
       "include-component-in-tag": false,
       "include-v-in-tag": true
     }


### PR DESCRIPTION
Starts releases at v0.1.0 and cleans up the initial changelog.