### PR TITLE
feat: support TextEdit shorthand for code actions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,10 @@ A producer can call `publish()` directly with normalized actions.
 Tool-specific adapters handle formats such as golangci-lint JSON, while integrations capture output another plugin already produced.
 The [nvim-lint](https://github.com/mfussenegger/nvim-lint) integration wraps its parser and never launches a second process.
 
+For same-buffer fixes, producers may put one `TextEdit` or a list of text edits in an action's `edit` field.
+Publication wraps that shorthand in a versioned `WorkspaceEdit`, which is the type required by the LSP `CodeAction` protocol.
+Producers can instead supply a full `WorkspaceEdit` for multi-document changes or resource operations.
+
 Actions are stored by buffer and source.
 Republishing replaces only that source, so several producers can coexist without coordinating with each other.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,6 @@ Test files follow `tests/test_<area>.lua`, where `<area>` names the module or in
 `test_offsets.lua`, `test_store.lua`, or `test_nvim_lint.lua`). Within a file, nest cases under the public function
 name such as `to_position()` or `attach()`. Shared setup belongs in `tests/helpers.lua`.
 
-Run one file with `make test-file FILE=tests/test_offsets.lua`.
-
 To exercise the pull-request workflow locally, start Docker and install [`act`](https://github.com/nektos/act):
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -62,12 +62,46 @@ lint_actions.publish({
       action = {
         title = 'Apply suggested fix',
         kind = 'quickfix',
-        edit = workspace_edit,
+        edit = { range = edit_range, newText = replacement },
       },
     },
   },
 })
 ```
+
+`action.edit` accepts one `lsp.TextEdit`, a list of text edits, or an
+`lsp.WorkspaceEdit`. A text edit only describes a range replacement, so
+`publish()` targets it at `bufnr` and wraps it in a versioned workspace edit.
+This is the recommended form for ordinary same-buffer linter fixes:
+
+```lua
+action = {
+  title = 'Apply all replacements',
+  kind = 'quickfix',
+  edit = {
+    { range = first_range, newText = first_replacement },
+    { range = second_range, newText = second_replacement },
+  },
+}
+```
+
+Use a full workspace edit when an action changes several documents or performs
+ordered file operations:
+
+```lua
+action.edit = {
+  documentChanges = {
+    { textDocument = { uri = first_uri }, edits = first_edits },
+    { textDocument = { uri = second_uri }, edits = second_edits },
+  },
+}
+```
+
+Both inputs are returned to Neovim as `CodeAction`s containing a
+`WorkspaceEdit`, so preview-capable code-action pickers can compute a diff for
+either one. An opaque `command`, rather than the choice between `TextEdit` and
+`WorkspaceEdit`, is what normally prevents an edit preview. Neovim's built-in
+code-action selector applies edits but does not itself render a diff preview.
 
 See [the architecture note](ARCHITECTURE.md) for the data flow and stale-edit guarantees.
 

--- a/doc/lint-actions.txt
+++ b/doc/lint-actions.txt
@@ -27,7 +27,22 @@ Neovim 0.11 or newer is required.
     Fields: ~
       bufnr   Buffer receiving the actions.
       source  Stable producer identifier.
-      items   List of `{ range = lsp.Range, action = lsp.CodeAction }`.
+      items   List of `{ range = lsp.Range, action = action }`. Each action is
+              an `lsp.CodeAction`, except its `edit` may also be one
+              `lsp.TextEdit` or a list of text edits targeting `bufnr`.
+
+    Same-buffer fixes should normally use the TextEdit shorthand: >lua
+
+      action = {
+        title = 'Apply suggested fix',
+        kind = 'quickfix',
+        edit = { range = edit_range, newText = replacement },
+      }
+<
+    `publish()` wraps text edits in a versioned `lsp.WorkspaceEdit`. Supply a
+    full WorkspaceEdit for multi-document edits or file operations. Both forms
+    remain declarative and can be diffed by preview-capable code-action UIs;
+    command-only actions generally cannot be previewed.
 
                                                                *lint_actions.clear()*
 `clear({opts})`

--- a/lua/lint_actions/adapters/golangci.lua
+++ b/lua/lint_actions/adapters/golangci.lua
@@ -97,7 +97,6 @@ function M.parse(context)
   end
 
   local filename = absolute(vim.api.nvim_buf_get_name(context.bufnr), context.cwd)
-  local uri = vim.uri_from_bufnr(context.bufnr)
   local text = offsets.buffer_text(context.bufnr)
   local ranges = diagnostic_ranges(context.diagnostics)
   local items = {}
@@ -121,14 +120,7 @@ function M.parse(context)
             action = {
               title = title,
               kind = 'quickfix',
-              edit = {
-                documentChanges = {
-                  {
-                    textDocument = { uri = uri },
-                    edits = edits,
-                  },
-                },
-              },
+              edit = edits,
             },
           })
         end

--- a/lua/lint_actions/init.lua
+++ b/lua/lint_actions/init.lua
@@ -39,6 +39,23 @@ local function version_edit(action, uri, version)
     return action
   end
 
+  -- Text edits do not identify their target document. Accept one edit or a
+  -- list as a convenient same-buffer shorthand, then put the protocol-correct
+  -- WorkspaceEdit on the CodeAction returned to Neovim.
+  local text_edit_range = rawget(edit, 'range')
+  if text_edit_range or vim.islist(edit) then
+    local edits = text_edit_range and { edit } or edit
+    action.edit = {
+      documentChanges = {
+        {
+          textDocument = { uri = uri, version = version },
+          edits = edits,
+        },
+      },
+    }
+    return action
+  end
+
   if edit.changes then
     edit.documentChanges = edit.documentChanges or {}
     for edit_uri, edits in pairs(edit.changes) do

--- a/lua/lint_actions/types.lua
+++ b/lua/lint_actions/types.lua
@@ -1,6 +1,11 @@
+---@alias LintActions.Edit lsp.TextEdit|lsp.TextEdit[]|lsp.WorkspaceEdit
+
+---@class LintActions.CodeAction : lsp.CodeAction
+---@field edit? LintActions.Edit A TextEdit or list targets the published buffer; a WorkspaceEdit may target multiple resources.
+
 ---@class LintActions.Item
 ---@field range lsp.Range Range in which the action is offered.
----@field action lsp.CodeAction Action returned to the LSP client.
+---@field action LintActions.CodeAction Action returned to the LSP client.
 
 ---@class LintActions.PublishOptions
 ---@field bufnr integer

--- a/tests/test_golangci.lua
+++ b/tests/test_golangci.lua
@@ -7,7 +7,7 @@ local T = MiniTest.new_set()
 
 T['parse()'] = MiniTest.new_set()
 
-T['parse()']['decodes fixes into workspace edits'] = function()
+T['parse()']['decodes fixes into text edits'] = function()
   local path = vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'golangci-decode.go')
   local lines = { 'package example', '', 'var status = 404' }
   local bufnr = helpers.new_buffer(path, lines)
@@ -40,8 +40,8 @@ T['parse()']['decodes fixes into workspace edits'] = function()
 
   eq(#items, 1)
   eq(items[1].action.title, 'Use the HTTP status constant [mnd]')
-  eq(items[1].action.edit.documentChanges[1].edits[1].newText, 'http.StatusNotFound')
-  eq(items[1].action.edit.documentChanges[1].edits[1].range.start, { line = 2, character = 13 })
+  eq(items[1].action.edit[1].newText, 'http.StatusNotFound')
+  eq(items[1].action.edit[1].range.start, { line = 2, character = 13 })
 end
 
 T['parse()']['uses matching diagnostic ranges'] = function()
@@ -135,7 +135,7 @@ T['parse()']['handles representative golangci-lint v2 output'] = function()
   eq(#items, 3)
   local by_title = {}
   for _, item in ipairs(items) do
-    by_title[item.action.title] = item.action.edit.documentChanges[1].edits
+    by_title[item.action.title] = item.action.edit
   end
   local error_edits = by_title['Use `%w` to format errors [errorlint]']
   eq(error_edits[1].newText, 'w')

--- a/tests/test_lint_actions.lua
+++ b/tests/test_lint_actions.lua
@@ -42,6 +42,48 @@ T['publish()']['versions current-buffer edits without mutating input'] = functio
   eq(published.edit.documentChanges[1].textDocument.version, vim.api.nvim_buf_get_changedtick(bufnr))
 end
 
+T['publish()']['wraps a text edit for the published buffer'] = function()
+  local bufnr = helpers.new_buffer('publish-text-edit.txt', { 'old text' })
+  local range = helpers.range(0, 0, 0, 3)
+  local action = {
+    title = 'Replace text',
+    edit = { range = range, newText = 'new' },
+  }
+
+  lint_actions.publish({
+    bufnr = bufnr,
+    source = 'tool',
+    items = { { range = range, action = action } },
+  })
+
+  local published = store.actions(bufnr, range)[1]
+  local document_edit = published.edit.documentChanges[1]
+  eq(action.edit, { range = range, newText = 'new' })
+  eq(document_edit.textDocument.uri, vim.uri_from_bufnr(bufnr))
+  eq(document_edit.textDocument.version, vim.api.nvim_buf_get_changedtick(bufnr))
+  eq(document_edit.edits, { { range = range, newText = 'new' } })
+end
+
+T['publish()']['wraps a list of text edits for the published buffer'] = function()
+  local bufnr = helpers.new_buffer('publish-text-edits.txt', { 'old text' })
+  local first = { range = helpers.range(0, 0, 0, 3), newText = 'new' }
+  local second = { range = helpers.range(0, 4, 0, 8), newText = 'value' }
+
+  lint_actions.publish({
+    bufnr = bufnr,
+    source = 'tool',
+    items = {
+      {
+        range = first.range,
+        action = { title = 'Replace text', edit = { first, second } },
+      },
+    },
+  })
+
+  local published = store.actions(bufnr, first.range)[1]
+  eq(published.edit.documentChanges[1].edits, { first, second })
+end
+
 local invalid_publications = {
   {
     'rejects a missing options table',


### PR DESCRIPTION
Allow publishers to provide a single TextEdit, a list of TextEdits, or a complete WorkspaceEdit.

Same-buffer TextEdits are normalized into versioned WorkspaceEdits before being exposed through LSP. This keeps actions protocol-compliant, preserves stale-edit protection, and allows preview-capable code-action UIs to generate diffs.

The golangci-lint adapter now uses the simpler TextEdit-list form. Documentation and tests cover both input styles and clarify that command-only actions—not TextEdit versus WorkspaceEdit—are what generally prevent previews.