### PR TITLE
feat: add markdownlint code actions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,8 +19,23 @@ flowchart LR
 ## Publishing
 
 A producer can call `publish()` directly with normalized actions.
-Tool-specific adapters handle formats such as golangci-lint JSON, while integrations capture output another plugin already produced.
+Tool-specific adapters handle formats such as golangci-lint and markdownlint
+JSON, while integrations capture output another plugin already produced.
 The [nvim-lint](https://github.com/mfussenegger/nvim-lint) integration wraps its parser and never launches a second process.
+
+### Parser interposition
+
+nvim-lint owns process execution and diagnostic publication, while each
+linter definition owns output interpretation through its `parser` function.
+The integration calls that parser first, passes both its diagnostics and the
+same raw output to the selected adapter, then returns the diagnostics to
+nvim-lint unchanged.
+
+This also supports richer output formats than a bundled linter definition
+uses by default. The producer must switch the command arguments and parser as
+one operation: for example, a `--json` argument must be paired with a JSON
+parser returning `vim.Diagnostic[]`. The adapter can then consume the JSON for
+fix metadata without disrupting nvim-lint's normal diagnostic flow.
 
 For same-buffer fixes, producers may put one `TextEdit` or a list of text edits in an action's `edit` field.
 Publication wraps that shorthand in a versioned `WorkspaceEdit`, which is the type required by the LSP `CodeAction` protocol.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ With `vim.pack` on Neovim 0.12 or newer:
 ```lua
 vim.pack.add({
   'https://github.com/geodimm/lint-actions.nvim',
-  'https://github.com/mfussenegger/nvim-lint',
 })
 ```
 
@@ -22,27 +21,34 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
   'geodimm/lint-actions.nvim',
-  dependencies = { 'mfussenegger/nvim-lint' },
 }
 ```
 
 ## Setup
 
-Connect fixes produced by [nvim-lint](https://github.com/mfussenegger/nvim-lint) and [golangci-lint](https://github.com/golangci/golangci-lint):
-
 ```lua
-local lint = require('lint')
-
 require('lint_actions').setup()
-require('lint_actions.integrations.nvim_lint').attach({
-  linter = 'golangcilint',
-  adapter = require('lint_actions.adapters.golangci'),
-})
-
-lint.linters_by_ft.go = { 'golangcilint' }
 ```
 
-Install the `golangci-lint` executable and trigger `nvim-lint` as usual. This plugin reuses the same process output; it does not run the linter again.
+Setup is idempotent and only installs buffer cleanup. Nothing runs until an
+integration or another producer publishes actions.
+
+## Integrations
+
+Integration-specific dependencies, configuration, and behavior live in
+versioned Vim help guides:
+
+- [golangci-lint with nvim-lint](doc/lint-actions-golangci.txt)
+- [markdownlint-cli with nvim-lint](doc/lint-actions-markdownlint.txt)
+
+They are also available inside Neovim with `:help lint-actions-golangci` and
+`:help lint-actions-markdownlint`.
+
+The nvim-lint bridge is also an extension point for other tools. It preserves
+diagnostics from any function-based nvim-lint parser while passing the same
+raw output to a fix adapter. If a tool needs a richer output format, configure
+its arguments and matching parser before attaching the bridge. See
+`:help lint-actions-nvim-lint`.
 
 ## Publishing actions
 

--- a/doc/lint-actions-golangci.txt
+++ b/doc/lint-actions-golangci.txt
@@ -1,0 +1,57 @@
+*lint-actions-golangci.txt*          golangci-lint actions through nvim-lint
+
+===============================================================================
+GOLANGCI-LINT                                      *lint-actions-golangci*
+
+This integration exposes `SuggestedFixes` from golangci-lint v2 JSON output
+as native Neovim code actions. It reuses nvim-lint's existing process output
+and does not run golangci-lint again.
+
+REQUIREMENTS ~
+
+- Neovim 0.11 or newer.
+- nvim-lint: https://github.com/mfussenegger/nvim-lint
+- golangci-lint v2 available as `golangci-lint`:
+  https://github.com/golangci/golangci-lint
+
+CONFIGURATION ~
+
+Attach lint-actions after loading nvim-lint, then configure and trigger the
+linter as usual: >lua
+
+  local lint = require('lint')
+
+  require('lint_actions').setup()
+  require('lint_actions.integrations.golangci').attach()
+
+  lint.linters_by_ft.go = { 'golangcilint' }
+<
+Trigger nvim-lint from a command, key mapping, or autocmd. Actions are
+published only when the buffer is unmodified, preventing fixes calculated for
+saved file contents from being applied to a different buffer state.
+
+ADVANCED CONFIGURATION ~
+
+The default linter name is `golangcilint`. Power users can supply a different
+name or concrete nvim-lint definition, and override the publication
+source: >lua
+
+  require('lint_actions.integrations.golangci').attach({
+    linter = require('lint').linters.golangcilint,
+    source = 'my-golangci',
+  })
+<
+For custom adapters or other nvim-lint tools, use the lower-level
+|lint-actions-nvim-lint| interface.
+
+ACTIONS ~
+
+Every valid `SuggestedFix` for the current file becomes a `quickfix` action.
+Its title uses the suggested-fix message when available and includes the
+originating linter name.
+
+Text edits are published as versioned workspace edits, so they become stale
+as soon as the buffer changes and remain compatible with preview-capable code
+action pickers.
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/lint-actions-markdownlint.txt
+++ b/doc/lint-actions-markdownlint.txt
@@ -1,0 +1,106 @@
+*lint-actions-markdownlint.txt*      markdownlint actions through nvim-lint
+
+===============================================================================
+MARKDOWNLINT                                    *lint-actions-markdownlint*
+
+This integration exposes structured fixes from markdownlint-cli as native
+Neovim code actions. It reuses nvim-lint's existing process output and does
+not run markdownlint again.
+
+REQUIREMENTS ~
+
+- Neovim 0.11 or newer.
+- nvim-lint: https://github.com/mfussenegger/nvim-lint
+- markdownlint-cli available as `markdownlint`:
+  https://github.com/igorshubovych/markdownlint-cli
+
+CONFIGURATION ~
+
+Attach the integration after loading nvim-lint: >lua
+
+  local lint = require('lint')
+
+  require('lint_actions').setup()
+  require('lint_actions.integrations.markdownlint').attach()
+
+  lint.linters_by_ft.markdown = { 'markdownlint' }
+<
+markdownlint's normal text output does not contain fix information. The
+integration adds `--json` to expose `fixInfo` and, in the same operation,
+replaces nvim-lint's text parser with a compatible JSON diagnostic parser.
+nvim-lint therefore continues to publish diagnostics from the new output
+format. Existing CLI arguments are preserved, and an existing `--json` is not
+duplicated.
+
+ADVANCED CONFIGURATION ~
+
+Configure additional CLI arguments before calling `attach()`; the integration
+preserves them: >lua
+
+  local markdownlint = require('lint').linters.markdownlint
+
+  markdownlint.args = vim.list_extend(markdownlint.args, {
+    '--config',
+    '/path/to/markdownlint.yaml',
+  })
+
+  require('lint_actions.integrations.markdownlint').attach()
+<
+The default linter name is `markdownlint`. Power users can supply a different
+name or concrete definition, and override the publication source: >lua
+
+  require('lint_actions.integrations.markdownlint').attach({
+    linter = 'my_markdownlint',
+    source = 'my-markdownlint',
+  })
+<
+For custom adapters or other nvim-lint tools, use the lower-level
+|lint-actions-nvim-lint| interface.
+
+Trigger nvim-lint after saving the buffer. For example: >lua
+
+  vim.api.nvim_create_autocmd('BufWritePost', {
+    pattern = '*.md',
+    callback = function()
+      require('lint').try_lint('markdownlint')
+    end,
+  })
+<
+Actions are published only when the buffer is unmodified. A lint run triggered
+while the buffer is modified can still update diagnostics, but its fixes are
+not retained because they cannot be proven to match the current buffer.
+
+ACTIONS ~
+
+Each fixable diagnostic gets a `quickfix` action such as: >text
+
+  Fix MD018: No space after hash on atx style heading
+<
+The integration also publishes a file-wide action with the kind
+`source.fixAll.markdownlint`: >text
+
+  Fix all markdownlint issues
+<
+The file-wide edit follows markdownlint's ordering, duplicate removal, and
+overlap handling. Diagnostics for rules without `fixInfo` remain visible but
+do not receive an individual action.
+
+DISABLING FORMAT ON SAVE ~
+
+If a formatter currently invokes `markdownlint --fix` on save, remove
+markdownlint from that format-on-save configuration. Keep it configured in
+nvim-lint so `BufWritePost` refreshes diagnostics and explicit code actions.
+
+For example, with Conform.nvim remove the markdown entry from
+`formatters_by_ft`: >lua
+
+  formatters_by_ft = {
+    -- markdown = { 'markdownlint' },
+  }
+<
+Conform.nvim: https://github.com/stevearc/conform.nvim
+
+The formatter-specific markdownlint definition can also be removed once
+nothing else references it.
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/lint-actions.txt
+++ b/doc/lint-actions.txt
@@ -5,7 +5,7 @@ CONTENTS                                                     *lint-actions-conte
 
 1. Introduction                                      |lint-actions-introduction|
 2. Publishing                                              |lint-actions-publish|
-3. Adapters                                                |lint-actions-adapters|
+3. Integrations                                        |lint-actions-integrations|
 4. Health                                                    |lint-actions-health|
 
 ===============================================================================
@@ -53,18 +53,74 @@ Neovim 0.11 or newer is required.
     Parses tool output with `opts.adapter` and publishes the returned items.
 
 ===============================================================================
-3. ADAPTERS                                                     *lint-actions-adapters*
+3. INTEGRATIONS             *lint-actions-integrations* *lint-actions-adapters*
 
-The bundled golangci-lint v2 adapter reads JSON SuggestedFixes: >lua
+Bundled integrations reuse output from nvim-lint and do not launch a second
+linter process. Supported tools and their setup guides are: ~
 
-  require('lint_actions').setup()
+  golangci-lint   |lint-actions-golangci|
+  markdownlint    |lint-actions-markdownlint|
+
+Those guides document dependencies, configuration, available actions, and
+tool-specific caveats.
+
+NVIM-LINT ADAPTER API                              *lint-actions-nvim-lint*
+
+The nvim-lint framework delegates output interpretation to each linter's
+`parser` function. lint-actions wraps that function without taking over
+diagnostic publication: ~
+
+  1. nvim-lint runs the configured command.
+  2. The linter's parser turns its output into `vim.Diagnostic[]`.
+  3. lint-actions passes the same raw output and diagnostics to the adapter.
+  4. The adapter returns code-action items.
+  5. The original diagnostics are returned unchanged to nvim-lint.
+
+This makes any function-based nvim-lint parser an integration point. Power
+users can connect it to a compatible adapter: >lua
+
   require('lint_actions.integrations.nvim_lint').attach({
-    linter = 'golangcilint',
-    adapter = require('lint_actions.adapters.golangci'),
+    linter = 'linter-name',
+    adapter = require('my_adapter'),
+    source = 'optional-source-override',
   })
 <
-The nvim-lint integration wraps the existing parser and does not run another
-linter process.
+`linter` accepts a registered nvim-lint name or a concrete linter definition.
+The adapter must expose `source` and `parse(context)`. The integration wraps
+the existing parser, preserves its diagnostics, and passes the same process
+output to the adapter. It does not change the linter command or arguments.
+
+CHANGING THE OUTPUT FORMAT ~
+
+An adapter may need structured output that the bundled nvim-lint parser does
+not understand. Configure the command arguments and a matching parser before
+attaching lint-actions: >lua
+
+  local lint = require('lint')
+  local adapter = require('my_json_adapter')
+  local linter = lint.linters.my_linter
+
+  table.insert(linter.args, '--json')
+  linter.parser = adapter.diagnostics
+
+  require('lint_actions.integrations.nvim_lint').attach({
+    linter = linter,
+    adapter = adapter,
+  })
+<
+The replacement parser must accept `(output, bufnr, cwd)` and return
+`vim.Diagnostic[]`. The adapter's `parse(context)` receives `context.output`,
+`context.bufnr`, `context.cwd`, and those parsed `context.diagnostics`.
+
+Changing only the output argument would leave the old parser reading the
+wrong format and break diagnostics. Changing the argument and parser together
+keeps nvim-lint diagnostics working while exposing richer data to the adapter.
+The markdownlint integration, |lint-actions-markdownlint|, is a complete
+example of this pattern.
+
+Producers that already have normalized actions can bypass nvim-lint and use
+|lint_actions.publish()|. Raw output can be passed directly through an adapter
+with |lint_actions.ingest()|.
 
 ===============================================================================
 4. HEALTH                                                         *lint-actions-health*

--- a/lua/lint_actions/adapters/markdownlint.lua
+++ b/lua/lint_actions/adapters/markdownlint.lua
@@ -1,0 +1,317 @@
+local offsets = require('lint_actions.offsets')
+
+local M = { source = 'markdownlint' }
+
+local function decode(output)
+  if type(output) ~= 'string' or output == '' then
+    return {}
+  end
+
+  local ok, result = pcall(vim.json.decode, output)
+  return ok and vim.islist(result) and result or {}
+end
+
+local function rule_name(issue)
+  for _, name in ipairs(type(issue.ruleNames) == 'table' and issue.ruleNames or {}) do
+    if type(name) == 'string' and name:match('^MD%d+$') then
+      return name
+    end
+  end
+  local name = type(issue.ruleNames) == 'table' and issue.ruleNames[1] or nil
+  return type(name) == 'string' and name or 'markdownlint'
+end
+
+local function message(issue)
+  local names = {}
+  for _, name in ipairs(type(issue.ruleNames) == 'table' and issue.ruleNames or {}) do
+    if type(name) == 'string' then
+      table.insert(names, name)
+    end
+  end
+
+  local description = type(issue.ruleDescription) == 'string' and issue.ruleDescription or 'Markdown lint issue'
+  if type(issue.errorDetail) == 'string' and issue.errorDetail ~= '' then
+    description = ('%s [%s]'):format(description, issue.errorDetail)
+  end
+  if type(issue.errorContext) == 'string' and issue.errorContext ~= '' then
+    description = ('%s [Context: "%s"]'):format(description, issue.errorContext)
+  end
+
+  return #names > 0 and table.concat(names, '/') .. ' ' .. description or description
+end
+
+local function line(bufnr, line_number)
+  return vim.api.nvim_buf_get_lines(bufnr, line_number - 1, line_number, false)[1] or ''
+end
+
+local function to_byte(text, utf16_index)
+  local ok, byte_index = pcall(vim.str_byteindex, text, 'utf-16', math.max(utf16_index, 0), false)
+  return ok and byte_index or #text
+end
+
+local function issue_range(issue, bufnr)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  local line_number = type(issue.lineNumber) == 'number' and math.floor(issue.lineNumber) or 1
+  line_number = math.max(1, math.min(line_number, line_count))
+  local text = line(bufnr, line_number)
+  local range = type(issue.errorRange) == 'table' and issue.errorRange or nil
+  local start_utf16 = range and type(range[1]) == 'number' and math.max(range[1] - 1, 0) or 0
+  local length_utf16 = range and type(range[2]) == 'number' and math.max(range[2], 0) or 0
+
+  return {
+    start = { line = line_number - 1, character = to_byte(text, start_utf16) },
+    ['end'] = { line = line_number - 1, character = to_byte(text, start_utf16 + length_utf16) },
+  }
+end
+
+local function normalize_fix(issue, bufnr)
+  local fix = type(issue.fixInfo) == 'table' and issue.fixInfo or nil
+  if not fix then
+    return nil
+  end
+
+  local line_number = fix.lineNumber or issue.lineNumber
+  local edit_column = fix.editColumn or 1
+  local delete_count = fix.deleteCount or 0
+  local insert_text = fix.insertText or ''
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  if
+    type(line_number) ~= 'number'
+    or line_number ~= math.floor(line_number)
+    or line_number < 1
+    or line_number > line_count
+    or type(edit_column) ~= 'number'
+    or edit_column ~= math.floor(edit_column)
+    or edit_column < 1
+    or type(delete_count) ~= 'number'
+    or delete_count ~= math.floor(delete_count)
+    or delete_count < -1
+    or type(insert_text) ~= 'string'
+  then
+    return nil
+  end
+
+  local line_length = vim.str_utfindex(line(bufnr, line_number), 'utf-16')
+  if edit_column > line_length + 1 or (delete_count >= 0 and edit_column - 1 + delete_count > line_length) then
+    return nil
+  end
+
+  return {
+    line_number = line_number,
+    edit_column = edit_column,
+    delete_count = delete_count,
+    insert_text = insert_text,
+  }
+end
+
+local function full_range(bufnr)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  if vim.bo[bufnr].endofline then
+    return { start = { line = 0, character = 0 }, ['end'] = { line = #lines, character = 0 } }
+  end
+  local last = lines[#lines] or ''
+  return {
+    start = { line = 0, character = 0 },
+    ['end'] = { line = math.max(#lines - 1, 0), character = #last },
+  }
+end
+
+local function fix_edit(fix, bufnr)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local row = fix.line_number - 1
+  local text = lines[fix.line_number] or ''
+
+  if fix.delete_count == -1 then
+    if #lines == 1 then
+      return { range = full_range(bufnr), newText = '' }
+    elseif fix.line_number < #lines then
+      return {
+        range = { start = { line = row, character = 0 }, ['end'] = { line = row + 1, character = 0 } },
+        newText = '',
+      }
+    end
+    return {
+      range = {
+        start = { line = row - 1, character = #(lines[fix.line_number - 1] or '') },
+        ['end'] = { line = row, character = #text },
+      },
+      newText = '',
+    }
+  end
+
+  local start_utf16 = fix.edit_column - 1
+  return {
+    range = {
+      start = { line = row, character = to_byte(text, start_utf16) },
+      ['end'] = { line = row, character = to_byte(text, start_utf16 + fix.delete_count) },
+    },
+    newText = fix.insert_text,
+  }
+end
+
+local function apply_fixes(bufnr, fixes)
+  fixes = vim.deepcopy(fixes)
+  table.sort(fixes, function(left, right)
+    if left.line_number ~= right.line_number then
+      return left.line_number > right.line_number
+    end
+    local left_deletes_line = left.delete_count == -1
+    local right_deletes_line = right.delete_count == -1
+    if left_deletes_line ~= right_deletes_line then
+      return not left_deletes_line
+    end
+    if left.edit_column ~= right.edit_column then
+      return left.edit_column > right.edit_column
+    end
+    return vim.str_utfindex(left.insert_text, 'utf-16') > vim.str_utfindex(right.insert_text, 'utf-16')
+  end)
+
+  local unique = {}
+  for _, fix in ipairs(fixes) do
+    local previous = unique[#unique]
+    if
+      not previous
+      or fix.line_number ~= previous.line_number
+      or fix.edit_column ~= previous.edit_column
+      or fix.delete_count ~= previous.delete_count
+      or fix.insert_text ~= previous.insert_text
+    then
+      table.insert(unique, fix)
+    end
+  end
+
+  local collapsed = {}
+  for _, fix in ipairs(unique) do
+    local previous = collapsed[#collapsed]
+    if
+      previous
+      and fix.line_number == previous.line_number
+      and fix.edit_column == previous.edit_column
+      and fix.insert_text == ''
+      and fix.delete_count > 0
+      and previous.insert_text ~= ''
+      and previous.delete_count == 0
+    then
+      fix.insert_text = previous.insert_text
+      table.remove(collapsed)
+    end
+    table.insert(collapsed, fix)
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local deleted = {}
+  local last_line = -1
+  local last_column = -1
+  for _, fix in ipairs(collapsed) do
+    local line_number = fix.line_number
+    local column = fix.edit_column - 1
+    local does_not_overlap = line_number ~= last_line
+      or fix.delete_count == -1
+      or column + fix.delete_count <= last_column - (fix.delete_count > 0 and 0 or 1)
+    if does_not_overlap then
+      if fix.delete_count == -1 then
+        deleted[line_number] = true
+      else
+        local text = lines[line_number] or ''
+        local start_byte = to_byte(text, column)
+        local end_byte = to_byte(text, column + fix.delete_count)
+        local insert_text = fix.insert_text:gsub('\r\n', '\n'):gsub('\r', '\n')
+        lines[line_number] = text:sub(1, start_byte) .. insert_text .. text:sub(end_byte + 1)
+      end
+    end
+    last_line = line_number
+    last_column = column
+  end
+
+  local kept = {}
+  for index, text in ipairs(lines) do
+    if not deleted[index] then
+      table.insert(kept, text)
+    end
+  end
+
+  local fixed = table.concat(kept, '\n')
+  if #kept > 0 and vim.bo[bufnr].endofline then
+    fixed = fixed .. '\n'
+  end
+  return fixed
+end
+
+---Parse markdownlint-cli JSON output into nvim-lint diagnostics.
+---@param output string
+---@param bufnr integer
+---@return vim.Diagnostic[]
+function M.diagnostics(output, bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return {}
+  end
+
+  local diagnostics = {}
+  for _, issue in ipairs(decode(output)) do
+    if type(issue) == 'table' then
+      local range = issue_range(issue, bufnr)
+      table.insert(diagnostics, {
+        lnum = range.start.line,
+        col = range.start.character,
+        end_lnum = range['end'].line,
+        end_col = range['end'].character,
+        severity = vim.diagnostic.severity.WARN,
+        source = M.source,
+        code = rule_name(issue),
+        message = message(issue),
+      })
+    end
+  end
+  return diagnostics
+end
+
+---Translate markdownlint-cli JSON fixInfo entries into native code actions.
+---@param context LintActions.AdapterContext
+---@return LintActions.Item[]
+function M.parse(context)
+  if not vim.api.nvim_buf_is_valid(context.bufnr) then
+    return {}
+  end
+
+  local items = {}
+  local fixes = {}
+  for _, issue in ipairs(decode(context.output)) do
+    if type(issue) == 'table' then
+      local fix = normalize_fix(issue, context.bufnr)
+      if fix then
+        table.insert(fixes, fix)
+        table.insert(items, {
+          range = issue_range(issue, context.bufnr),
+          action = {
+            title = ('Fix %s: %s'):format(
+              rule_name(issue),
+              type(issue.ruleDescription) == 'string' and issue.ruleDescription or 'Markdown lint issue'
+            ),
+            kind = 'quickfix',
+            isPreferred = true,
+            edit = fix_edit(fix, context.bufnr),
+          },
+        })
+      end
+    end
+  end
+
+  if #fixes > 0 then
+    local original = offsets.buffer_text(context.bufnr):gsub('\r\n', '\n'):gsub('\r', '\n')
+    local fixed = apply_fixes(context.bufnr, fixes)
+    if fixed ~= original then
+      table.insert(items, {
+        range = full_range(context.bufnr),
+        action = {
+          title = 'Fix all markdownlint issues',
+          kind = 'source.fixAll.markdownlint',
+          edit = { range = full_range(context.bufnr), newText = fixed },
+        },
+      })
+    end
+  end
+
+  return items
+end
+
+return M

--- a/lua/lint_actions/integrations/golangci.lua
+++ b/lua/lint_actions/integrations/golangci.lua
@@ -1,0 +1,35 @@
+local adapter = require('lint_actions.adapters.golangci')
+local nvim_lint = require('lint_actions.integrations.nvim_lint')
+
+local M = {}
+
+---@class LintActions.GolangciOptions
+---@field linter? string|LintActions.NvimLintLinter Defaults to `golangcilint`.
+---@field source? string Overrides the adapter's source.
+
+---Publish golangci-lint SuggestedFixes from nvim-lint's existing output.
+---Calling this function more than once is safe.
+---@param options? LintActions.GolangciOptions
+function M.attach(options)
+  if options == nil then
+    options = {}
+  end
+  vim.validate('options', options, 'table')
+
+  local linter = options.linter
+  if linter == nil then
+    linter = 'golangcilint'
+  end
+  local source = options.source
+  if source == nil then
+    source = adapter.source
+  end
+
+  return nvim_lint.attach({
+    linter = linter,
+    adapter = adapter,
+    source = source,
+  })
+end
+
+return M

--- a/lua/lint_actions/integrations/markdownlint.lua
+++ b/lua/lint_actions/integrations/markdownlint.lua
@@ -1,0 +1,81 @@
+local adapter = require('lint_actions.adapters.markdownlint')
+local nvim_lint = require('lint_actions.integrations.nvim_lint')
+
+local M = {}
+local wrapped_factories = setmetatable({}, { __mode = 'k' })
+
+---@class LintActions.MarkdownlintLinter : LintActions.NvimLintLinter
+---@field _lint_actions_markdownlint_attached? boolean
+
+---@class LintActions.MarkdownlintOptions
+---@field linter? string|LintActions.MarkdownlintLinter Defaults to `markdownlint`.
+---@field source? string Overrides the adapter's source.
+
+---@param linter LintActions.MarkdownlintLinter
+---@param source string
+local function configure(linter, source)
+  if linter._lint_actions_markdownlint_attached then
+    return
+  end
+  if linter._lint_actions_attached then
+    error('attach the markdownlint integration before attaching this linter through nvim_lint')
+  end
+  if linter.args ~= nil and type(linter.args) ~= 'table' then
+    error('markdownlint linter args must be a table')
+  end
+
+  linter._lint_actions_markdownlint_attached = true
+  linter.args = linter.args or {}
+  if not vim.tbl_contains(linter.args, '--json') then
+    table.insert(linter.args, '--json')
+  end
+  linter.parser = adapter.diagnostics
+  nvim_lint.attach({ linter = linter, adapter = adapter, source = source })
+end
+
+---Configure markdownlint for JSON output and publish fixes from that output.
+---Calling this function more than once is safe.
+---@param options? LintActions.MarkdownlintOptions
+function M.attach(options)
+  if options == nil then
+    options = {}
+  end
+  vim.validate('options', options, 'table')
+
+  local source = options.source
+  if source == nil then
+    source = adapter.source
+  end
+  vim.validate('source', source, 'string')
+  local linter_option = options.linter
+  if linter_option == nil then
+    linter_option = 'markdownlint'
+  end
+  if type(linter_option) == 'string' then
+    local lint = require('lint')
+    local linter = lint.linters[linter_option]
+    if type(linter) == 'function' then
+      if wrapped_factories[linter] then
+        return
+      end
+      local factory = function()
+        local definition = linter()
+        vim.validate('linter definition', definition, 'table')
+        configure(definition, source)
+        return definition
+      end
+      wrapped_factories[factory] = true
+      lint.linters[linter_option] = factory
+    elseif type(linter) == 'table' then
+      configure(linter, source)
+    else
+      error(('unknown nvim-lint linter: %s'):format(linter_option))
+    end
+  elseif type(linter_option) == 'table' then
+    configure(linter_option, source)
+  else
+    error('options.linter must be a linter name or table')
+  end
+end
+
+return M

--- a/lua/lint_actions/integrations/nvim_lint.lua
+++ b/lua/lint_actions/integrations/nvim_lint.lua
@@ -5,6 +5,7 @@ local wrapped_factories = setmetatable({}, { __mode = 'k' })
 
 ---@class LintActions.NvimLintLinter
 ---@field parser LintActions.NvimLintParser
+---@field args? (string|fun(): string)[]
 ---@field _lint_actions_attached? boolean
 
 ---@class LintActions.NvimLintOptions
@@ -60,9 +61,12 @@ function M.attach(options)
   vim.validate('options', options, 'table')
   vim.validate('options.adapter', options.adapter, 'table')
   vim.validate('options.adapter.parse', options.adapter.parse, 'function')
-  vim.validate('source', options.source or options.adapter.source, 'string')
 
-  local source = options.source or options.adapter.source
+  local source = options.source
+  if source == nil then
+    source = options.adapter.source
+  end
+  vim.validate('source', source, 'string')
   local linter_option = options.linter
   if type(linter_option) == 'string' then
     local lint = require('lint')

--- a/tests/test_golangci_integration.lua
+++ b/tests/test_golangci_integration.lua
@@ -1,0 +1,58 @@
+local MiniTest = require('mini.test')
+local helpers = require('tests.helpers')
+local integration = require('lint_actions.integrations.golangci')
+
+local eq = helpers.eq
+local expect_error = helpers.expect_error
+local T = MiniTest.new_set()
+
+local function mock_nvim_lint(linters)
+  local previous = package.loaded.lint
+  package.loaded.lint = { linters = linters }
+  MiniTest.finally(function()
+    package.loaded.lint = previous
+  end)
+  return package.loaded.lint
+end
+
+local function linter()
+  return {
+    parser = function(_, _, _)
+      return {}
+    end,
+  }
+end
+
+T['attach()'] = MiniTest.new_set()
+
+T['attach()']['uses the default nvim-lint linter and bundled adapter'] = function()
+  local definition = linter()
+  mock_nvim_lint({ golangcilint = definition })
+
+  integration.attach()
+  local wrapped = definition.parser
+  integration.attach()
+
+  eq(definition._lint_actions_attached, true)
+  eq(definition.parser, wrapped)
+end
+
+T['attach()']['accepts a concrete linter and source override'] = function()
+  local definition = linter()
+  integration.attach({ linter = definition, source = 'custom-golangci' })
+  eq(definition._lint_actions_attached, true)
+end
+
+T['attach()']['rejects invalid options'] = function()
+  expect_error('options', function()
+    helpers.call(integration.attach, false)
+  end)
+  expect_error('options.linter must be a linter name or table', function()
+    helpers.call(integration.attach, { linter = false })
+  end)
+  expect_error('source', function()
+    helpers.call(integration.attach, { linter = linter(), source = false })
+  end)
+end
+
+return T

--- a/tests/test_markdownlint.lua
+++ b/tests/test_markdownlint.lua
@@ -1,0 +1,149 @@
+local MiniTest = require('mini.test')
+local adapter = require('lint_actions.adapters.markdownlint')
+local helpers = require('tests.helpers')
+
+local eq = helpers.eq
+local T = MiniTest.new_set()
+
+local function issue(options)
+  options = options or {}
+  return {
+    fileName = 'stdin',
+    lineNumber = options.line_number or 1,
+    ruleNames = options.rule_names or { 'MD018', 'no-missing-space-atx' },
+    ruleDescription = options.description or 'No space after hash on atx style heading',
+    ruleInformation = 'https://example.test/rule',
+    errorDetail = options.detail,
+    errorContext = options.context,
+    errorRange = options.range,
+    fixInfo = options.fix,
+    severity = 'error',
+  }
+end
+
+local function output(issues)
+  return vim.json.encode(issues)
+end
+
+local function apply(action, bufnr)
+  local edits = action.edit.range and { action.edit } or action.edit
+  vim.lsp.util.apply_text_edits(edits, bufnr, 'utf-8')
+end
+
+T['diagnostics()'] = MiniTest.new_set()
+
+T['diagnostics()']['parses messages, codes, and UTF-16 ranges'] = function()
+  local bufnr = helpers.new_buffer('markdownlint-diagnostics.md', { '😀#Title' })
+  local diagnostics = adapter.diagnostics(
+    output({
+      issue({
+        range = { 3, 2 },
+        detail = 'Expected: 1; Actual: 0',
+        context = '😀#Title',
+      }),
+    }),
+    bufnr
+  )
+
+  eq(#diagnostics, 1)
+  eq(diagnostics[1].lnum, 0)
+  eq(diagnostics[1].col, 4)
+  eq(diagnostics[1].end_col, 6)
+  eq(diagnostics[1].code, 'MD018')
+  eq(
+    diagnostics[1].message,
+    'MD018/no-missing-space-atx No space after hash on atx style heading '
+      .. '[Expected: 1; Actual: 0] [Context: "😀#Title"]'
+  )
+  eq(diagnostics[1].severity, vim.diagnostic.severity.WARN)
+end
+
+T['diagnostics()']['ignores empty, invalid, and non-array output'] = function()
+  local bufnr = helpers.new_buffer('markdownlint-invalid.md', { '# Heading' })
+  eq(adapter.diagnostics('', bufnr), {})
+  eq(adapter.diagnostics('{', bufnr), {})
+  eq(adapter.diagnostics('{}', bufnr), {})
+  eq(adapter.diagnostics('[]', -1), {})
+end
+
+T['parse()'] = MiniTest.new_set()
+
+T['parse()']['creates a quick fix for one diagnostic'] = function()
+  local bufnr = helpers.new_buffer('markdownlint-quickfix.md', { '#Title' })
+  local items = adapter.parse({
+    output = output({ issue({ range = { 1, 2 }, fix = { editColumn = 2, insertText = ' ' } }) }),
+    bufnr = bufnr,
+    cwd = vim.fn.getcwd(),
+  })
+
+  eq(#items, 2)
+  eq(items[1].range, helpers.range(0, 0, 0, 2))
+  eq(items[1].action.title, 'Fix MD018: No space after hash on atx style heading')
+  eq(items[1].action.kind, 'quickfix')
+  eq(items[1].action.isPreferred, true)
+  apply(items[1].action, bufnr)
+  eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), { '# Title' })
+end
+
+T['parse()']['creates a whole-file fix with markdownlint overlap handling'] = function()
+  local bufnr = helpers.new_buffer('markdownlint-fix-all.md', { 'bad', 'remove me' })
+  local issues = {
+    issue({
+      description = 'Insert replacement',
+      range = { 1, 3 },
+      fix = { editColumn = 1, insertText = 'good' },
+    }),
+    issue({
+      description = 'Delete old text',
+      range = { 1, 3 },
+      fix = { editColumn = 1, deleteCount = 3 },
+    }),
+    issue({
+      line_number = 2,
+      rule_names = { 'MD053', 'link-image-reference-definitions' },
+      description = 'Unused link definition',
+      fix = { deleteCount = -1 },
+    }),
+  }
+  local items = adapter.parse({ output = output(issues), bufnr = bufnr, cwd = vim.fn.getcwd() })
+
+  eq(#items, 4)
+  local fix_all = items[4].action
+  eq(fix_all.title, 'Fix all markdownlint issues')
+  eq(fix_all.kind, 'source.fixAll.markdownlint')
+  apply(fix_all, bufnr)
+  eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), { 'good' })
+end
+
+T['parse()']['targets UTF-16 fix columns with UTF-8 LSP positions'] = function()
+  local bufnr = helpers.new_buffer('markdownlint-unicode.md', { '😀bad' })
+  local items = adapter.parse({
+    output = output({ issue({ fix = { editColumn = 3, deleteCount = 3, insertText = 'good' } }) }),
+    bufnr = bufnr,
+    cwd = vim.fn.getcwd(),
+  })
+
+  eq(items[1].action.edit.range, helpers.range(0, 4, 0, 7))
+  apply(items[1].action, bufnr)
+  eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), { '😀good' })
+end
+
+T['parse()']['omits malformed and non-fixable issues'] = function()
+  local bufnr = helpers.new_buffer('markdownlint-nonfixable.md', { '# Heading' })
+  eq(
+    adapter.parse({
+      output = output({
+        issue(),
+        issue({ fix = { editColumn = 'first' } }),
+        issue({ fix = { lineNumber = 20, editColumn = 1 } }),
+      }),
+      bufnr = bufnr,
+      cwd = vim.fn.getcwd(),
+    }),
+    {}
+  )
+  eq(adapter.parse({ output = '{', bufnr = bufnr, cwd = vim.fn.getcwd() }), {})
+  eq(adapter.parse({ output = '[]', bufnr = -1, cwd = vim.fn.getcwd() }), {})
+end
+
+return T

--- a/tests/test_markdownlint_integration.lua
+++ b/tests/test_markdownlint_integration.lua
@@ -1,0 +1,102 @@
+local MiniTest = require('mini.test')
+local helpers = require('tests.helpers')
+local integration = require('lint_actions.integrations.markdownlint')
+local store = require('lint_actions.store')
+
+local eq = helpers.eq
+local expect_error = helpers.expect_error
+local T = MiniTest.new_set({
+  hooks = { pre_case = store._reset, post_case = store._reset },
+})
+
+local function mock_nvim_lint(linters)
+  local previous = package.loaded.lint
+  package.loaded.lint = { linters = linters }
+  MiniTest.finally(function()
+    package.loaded.lint = previous
+  end)
+  return package.loaded.lint
+end
+
+local function linter()
+  return {
+    args = { '--stdin', '--config', 'markdownlint.yaml' },
+    parser = function(_, _, _)
+      return {}
+    end,
+  }
+end
+
+T['attach()'] = MiniTest.new_set()
+
+T['attach()']['enables JSON and publishes actions from a concrete linter'] = function()
+  local definition = linter()
+  integration.attach({ linter = definition })
+  local wrapped = definition.parser
+  integration.attach({ linter = definition })
+
+  eq(definition.args, { '--stdin', '--config', 'markdownlint.yaml', '--json' })
+  eq(definition.parser, wrapped)
+  local bufnr = helpers.new_buffer('markdownlint-integration.md', { '#Title' })
+  local diagnostics = definition.parser(
+    vim.json.encode({
+      {
+        lineNumber = 1,
+        ruleNames = { 'MD018', 'no-missing-space-atx' },
+        ruleDescription = 'No space after hash on atx style heading',
+        errorRange = { 1, 2 },
+        fixInfo = { editColumn = 2, insertText = ' ' },
+      },
+    }),
+    bufnr,
+    vim.fn.getcwd()
+  )
+
+  eq(#diagnostics, 1)
+  eq(#store.actions(bufnr, helpers.range(0, 0, 0, 0)), 2)
+end
+
+T['attach()']['resolves and configures factory linters by name once'] = function()
+  local lint = mock_nvim_lint({
+    markdownlint = function()
+      return linter()
+    end,
+  })
+  integration.attach()
+  local factory = lint.linters.markdownlint
+  integration.attach()
+
+  eq(lint.linters.markdownlint, factory)
+  local definition = factory()
+  eq(definition.args, { '--stdin', '--config', 'markdownlint.yaml', '--json' })
+  eq(definition._lint_actions_markdownlint_attached, true)
+  eq(definition._lint_actions_attached, true)
+end
+
+T['attach()']['rejects invalid options and linter definitions'] = function()
+  expect_error('options', function()
+    helpers.call(integration.attach, false)
+  end)
+  expect_error('options.linter must be a linter name or table', function()
+    helpers.call(integration.attach, { linter = false })
+  end)
+  expect_error('source', function()
+    helpers.call(integration.attach, { linter = linter(), source = false })
+  end)
+  expect_error('markdownlint linter args must be a table', function()
+    helpers.call(integration.attach, { linter = { args = '--stdin' } })
+  end)
+  mock_nvim_lint({})
+  expect_error('unknown nvim-lint linter: missing', function()
+    helpers.call(integration.attach, { linter = 'missing' })
+  end)
+end
+
+T['attach()']['does not duplicate an existing JSON argument'] = function()
+  local definition = linter()
+  table.insert(definition.args, '--json')
+  integration.attach({ linter = definition })
+  eq(definition.args, { '--stdin', '--config', 'markdownlint.yaml', '--json' })
+end
+
+return T


### PR DESCRIPTION
Add markdownlint quick fixes and a file-wide fix-all action using JSON output from nvim-lint. Introduce symmetric golangci and markdownlint integration APIs, preserve diagnostics with a JSON-aware parser, and document custom nvim-lint adapter workflows in native Vim help.