### PR TITLE
feat: configure integrations through setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,42 @@ require('lint_actions').setup()
 
 The bundled integrations require
 [nvim-lint](https://github.com/mfussenegger/nvim-lint). After installing and
-configuring nvim-lint, attach the integrations for the linters you use:
+configuring nvim-lint, enable the integrations for the linters you use:
 
 ```lua
-require('lint_actions.integrations.golangci').attach()
-require('lint_actions.integrations.markdownlint').attach()
+require('lint_actions').setup({
+  integrations = {
+    nvim_lint = {
+      golangci = true,
+      markdownlint = true,
+    },
+  },
+})
 ```
 
-Setup and integration attachment are idempotent. lint-actions does not run
-linters itself; the integrations reuse output from your existing nvim-lint
-runs.
+Use `true` for the defaults or an options table for an integration-specific
+override:
+
+```lua
+require('lint_actions').setup({
+  integrations = {
+    nvim_lint = {
+      golangci = {
+        linter = 'my_golangcilint',
+        source = 'my-golangci',
+      },
+    },
+  },
+})
+```
+
+Setup is additive and idempotent: later calls may enable more integrations,
+and attaching an already attached integration is harmless. `false` leaves an
+integration disabled; it does not detach one enabled by an earlier call.
+
+lint-actions does not run linters itself. Its integrations reuse output from
+your existing nvim-lint runs. The direct integration `attach()` functions
+remain available for lower-level configuration.
 
 ## Integrations
 

--- a/doc/lint-actions-golangci.txt
+++ b/doc/lint-actions-golangci.txt
@@ -16,15 +16,19 @@ REQUIREMENTS ~
 
 CONFIGURATION ~
 
-Attach lint-actions after loading nvim-lint, then configure and trigger the
-linter as usual: >lua
+Configure nvim-lint first, then enable lint-actions and trigger the linter as
+usual: >lua
 
   local lint = require('lint')
-
-  require('lint_actions').setup()
-  require('lint_actions.integrations.golangci').attach()
-
   lint.linters_by_ft.go = { 'golangcilint' }
+
+  require('lint_actions').setup({
+    integrations = {
+      nvim_lint = {
+        golangci = true,
+      },
+    },
+  })
 <
 Trigger nvim-lint from a command, key mapping, or autocmd. Actions are
 published only when the buffer is unmodified, preventing fixes calculated for
@@ -36,11 +40,20 @@ The default linter name is `golangcilint`. Power users can supply a different
 name or concrete nvim-lint definition, and override the publication
 source: >lua
 
-  require('lint_actions.integrations.golangci').attach({
-    linter = require('lint').linters.golangcilint,
-    source = 'my-golangci',
+  require('lint_actions').setup({
+    integrations = {
+      nvim_lint = {
+        golangci = {
+          linter = require('lint').linters.golangcilint,
+          source = 'my-golangci',
+        },
+      },
+    },
   })
 <
+The lower-level `require('lint_actions.integrations.golangci').attach()` API
+accepts the same integration options.
+
 For custom adapters or other nvim-lint tools, use the lower-level
 |lint-actions-nvim-lint| interface.
 

--- a/doc/lint-actions-markdownlint.txt
+++ b/doc/lint-actions-markdownlint.txt
@@ -16,14 +16,18 @@ REQUIREMENTS ~
 
 CONFIGURATION ~
 
-Attach the integration after loading nvim-lint: >lua
+Configure nvim-lint first, then enable the integration: >lua
 
   local lint = require('lint')
-
-  require('lint_actions').setup()
-  require('lint_actions.integrations.markdownlint').attach()
-
   lint.linters_by_ft.markdown = { 'markdownlint' }
+
+  require('lint_actions').setup({
+    integrations = {
+      nvim_lint = {
+        markdownlint = true,
+      },
+    },
+  })
 <
 markdownlint's normal text output does not contain fix information. The
 integration adds `--json` to expose `fixInfo` and, in the same operation,
@@ -44,16 +48,31 @@ preserves them: >lua
     '/path/to/markdownlint.yaml',
   })
 
-  require('lint_actions.integrations.markdownlint').attach()
+  require('lint_actions').setup({
+    integrations = {
+      nvim_lint = {
+        markdownlint = true,
+      },
+    },
+  })
 <
 The default linter name is `markdownlint`. Power users can supply a different
 name or concrete definition, and override the publication source: >lua
 
-  require('lint_actions.integrations.markdownlint').attach({
-    linter = 'my_markdownlint',
-    source = 'my-markdownlint',
+  require('lint_actions').setup({
+    integrations = {
+      nvim_lint = {
+        markdownlint = {
+          linter = 'my_markdownlint',
+          source = 'my-markdownlint',
+        },
+      },
+    },
   })
 <
+The lower-level `require('lint_actions.integrations.markdownlint').attach()`
+API accepts the same integration options.
+
 For custom adapters or other nvim-lint tools, use the lower-level
 |lint-actions-nvim-lint| interface.
 

--- a/doc/lint-actions.txt
+++ b/doc/lint-actions.txt
@@ -4,9 +4,10 @@
 CONTENTS                                                     *lint-actions-contents*
 
 1. Introduction                                      |lint-actions-introduction|
-2. Publishing                                              |lint-actions-publish|
-3. Integrations                                        |lint-actions-integrations|
-4. Health                                                    |lint-actions-health|
+2. Setup                                                    |lint-actions-setup|
+3. Publishing                                              |lint-actions-publish|
+4. Integrations                                        |lint-actions-integrations|
+5. Health                                                    |lint-actions-health|
 
 ===============================================================================
 1. INTRODUCTION                                         *lint-actions-introduction*
@@ -17,7 +18,37 @@ LSP code actions. It does not run tools or replace |vim.lsp.buf.code_action()|.
 Neovim 0.11 or newer is required.
 
 ===============================================================================
-2. PUBLISHING                                                   *lint-actions-publish*
+2. SETUP                                                         *lint-actions-setup*
+
+                                                                 *lint_actions.setup()*
+`setup({opts})`
+    Initializes lint-actions. The core has no dependencies: >lua
+
+      require('lint_actions').setup()
+<
+    Bundled integrations require nvim-lint. Configure nvim-lint first, then
+    enable tools with `true` for their defaults or an options table: >lua
+
+      require('lint_actions').setup({
+        integrations = {
+          nvim_lint = {
+            golangci = true,
+            markdownlint = {
+              source = 'my-markdownlint',
+            },
+          },
+        },
+      })
+<
+    Calls are additive and idempotent. A later call may enable another
+    integration. `false` leaves an integration disabled but does not detach
+    one enabled earlier.
+
+    Integrations reuse nvim-lint output and never run linters themselves. See
+    |lint-actions-integrations| for their requirements and options.
+
+===============================================================================
+3. PUBLISHING                                                   *lint-actions-publish*
 
                                                              *lint_actions.publish()*
 `publish({opts})`
@@ -53,7 +84,7 @@ Neovim 0.11 or newer is required.
     Parses tool output with `opts.adapter` and publishes the returned items.
 
 ===============================================================================
-3. INTEGRATIONS             *lint-actions-integrations* *lint-actions-adapters*
+4. INTEGRATIONS             *lint-actions-integrations* *lint-actions-adapters*
 
 Bundled integrations reuse output from nvim-lint and do not launch a second
 linter process. Supported tools and their setup guides are: ~
@@ -123,7 +154,7 @@ Producers that already have normalized actions can bypass nvim-lint and use
 with |lint_actions.ingest()|.
 
 ===============================================================================
-4. HEALTH                                                         *lint-actions-health*
+5. HEALTH                                                         *lint-actions-health*
 
 Run `:checkhealth lint_actions` to check the Neovim requirement.
 

--- a/lua/lint_actions/init.lua
+++ b/lua/lint_actions/init.lua
@@ -1,6 +1,12 @@
 local M = {}
 
 local configured = false
+local integration_modules = {
+  nvim_lint = {
+    golangci = 'lint_actions.integrations.golangci',
+    markdownlint = 'lint_actions.integrations.markdownlint',
+  },
+}
 
 local function expect(value, expected, name)
   if type(value) ~= expected then
@@ -75,19 +81,81 @@ local function version_edit(action, uri, version)
   return action
 end
 
----Set up buffer cleanup. Calling this function more than once is safe.
-function M.setup()
-  if configured then
-    return
-  end
-  configured = true
+---@param integrations table<string, boolean|table>
+local function validate_integrations(integrations)
+  expect(integrations, 'table', 'options.integrations')
 
-  vim.api.nvim_create_autocmd('BufWipeout', {
-    group = vim.api.nvim_create_augroup('lint_actions', { clear = true }),
-    callback = function(event)
-      require('lint_actions.store').clear(event.buf)
-    end,
-  })
+  for integration, tools in pairs(integrations) do
+    local modules = integration_modules[integration]
+    if not modules then
+      error(('unknown integration: %s'):format(integration), 3)
+    end
+    if tools ~= false then
+      if type(tools) ~= 'table' then
+        error(('options.integrations.%s must be table, got %s'):format(integration, type(tools)), 3)
+      end
+      for tool, options in pairs(tools) do
+        if not modules[tool] then
+          error(('unknown %s integration: %s'):format(integration, tool), 3)
+        end
+        if options ~= false then
+          if options ~= true and type(options) ~= 'table' then
+            error(
+              ('options.integrations.%s.%s must be boolean or table, got %s'):format(integration, tool, type(options)),
+              3
+            )
+          end
+        end
+      end
+    end
+  end
+end
+
+---@param integrations table<string, boolean|table>
+local function attach_integrations(integrations)
+  for integration, tools in pairs(integrations) do
+    if tools ~= false then
+      ---@cast tools table
+      for tool, options in pairs(tools) do
+        if options ~= false then
+          require(integration_modules[integration][tool]).attach(options == true and {} or options)
+        end
+      end
+    end
+  end
+end
+
+---Set up buffer cleanup and enable configured integrations.
+---Calling this function more than once is safe; new integrations are attached.
+---@param options? LintActions.SetupOptions
+function M.setup(options)
+  if options == nil then
+    options = {}
+  end
+  expect(options, 'table', 'options')
+  for name in pairs(options) do
+    if name ~= 'integrations' then
+      error(('unknown setup option: %s'):format(name), 2)
+    end
+  end
+
+  if options.integrations ~= nil then
+    validate_integrations(options.integrations)
+  end
+
+  if not configured then
+    configured = true
+    vim.api.nvim_create_autocmd('BufWipeout', {
+      group = vim.api.nvim_create_augroup('lint_actions', { clear = true }),
+      callback = function(event)
+        require('lint_actions.store').clear(event.buf)
+      end,
+    })
+  end
+
+  if options.integrations ~= nil then
+    attach_integrations(options.integrations)
+  end
 end
 
 ---Replace the actions published by one source for a buffer.

--- a/lua/lint_actions/types.lua
+++ b/lua/lint_actions/types.lua
@@ -1,5 +1,15 @@
 ---@alias LintActions.Edit lsp.TextEdit|lsp.TextEdit[]|lsp.WorkspaceEdit
 
+---@class LintActions.NvimLintIntegrationOptions
+---@field golangci? boolean|LintActions.GolangciOptions Enable with defaults using `true`, or pass integration options.
+---@field markdownlint? boolean|LintActions.MarkdownlintOptions Enable with defaults using `true`, or pass integration options.
+
+---@class LintActions.IntegrationsOptions
+---@field nvim_lint? false|LintActions.NvimLintIntegrationOptions Tools whose nvim-lint output should provide actions.
+
+---@class LintActions.SetupOptions
+---@field integrations? LintActions.IntegrationsOptions Bundled integrations to attach after their dependencies are configured.
+
 ---@class LintActions.CodeAction : lsp.CodeAction
 ---@field edit? LintActions.Edit A TextEdit or list targets the published buffer; a WorkspaceEdit may target multiple resources.
 

--- a/tests/test_lint_actions.lua
+++ b/tests/test_lint_actions.lua
@@ -9,6 +9,93 @@ local T = MiniTest.new_set({
   hooks = { pre_case = store._reset, post_case = store._reset },
 })
 
+T['setup()'] = MiniTest.new_set()
+
+local function mock_integration(name, attach)
+  local module = 'lint_actions.integrations.' .. name
+  local previous = package.loaded[module]
+  package.loaded[module] = { attach = attach }
+  MiniTest.finally(function()
+    package.loaded[module] = previous
+  end)
+end
+
+T['setup()']['enables integrations with defaults or options'] = function()
+  local calls = {}
+  mock_integration('golangci', function(options)
+    calls.golangci = options
+  end)
+  mock_integration('markdownlint', function(options)
+    calls.markdownlint = options
+  end)
+
+  lint_actions.setup({
+    integrations = {
+      nvim_lint = {
+        golangci = true,
+        markdownlint = { source = 'custom-markdownlint' },
+      },
+    },
+  })
+
+  eq(calls.golangci, {})
+  eq(calls.markdownlint, { source = 'custom-markdownlint' })
+end
+
+T['setup()']['can attach integrations on a later call'] = function()
+  local calls = 0
+  mock_integration('golangci', function()
+    calls = calls + 1
+  end)
+
+  lint_actions.setup()
+  lint_actions.setup({ integrations = { nvim_lint = { golangci = true } } })
+
+  eq(calls, 1)
+end
+
+T['setup()']['ignores explicitly disabled integrations'] = function()
+  local calls = 0
+  mock_integration('golangci', function()
+    calls = calls + 1
+  end)
+
+  lint_actions.setup({ integrations = { nvim_lint = { golangci = false } } })
+  lint_actions.setup({ integrations = { nvim_lint = false } })
+
+  eq(calls, 0)
+end
+
+T['setup()']['rejects invalid options and integrations'] = function()
+  local calls = 0
+  mock_integration('golangci', function()
+    calls = calls + 1
+  end)
+
+  expect_error('options must be table, got boolean', function()
+    helpers.call(lint_actions.setup, false)
+  end)
+  expect_error('options.integrations must be table, got boolean', function()
+    helpers.call(lint_actions.setup, { integrations = true })
+  end)
+  expect_error('unknown setup option: integration', function()
+    lint_actions.setup({ integration = {} })
+  end)
+  expect_error('unknown integration: missing', function()
+    lint_actions.setup({ integrations = { missing = true } })
+  end)
+  expect_error('options.integrations.nvim_lint must be table, got boolean', function()
+    helpers.call(lint_actions.setup, { integrations = { nvim_lint = true } })
+  end)
+  expect_error('unknown nvim_lint integration: missing', function()
+    lint_actions.setup({ integrations = { nvim_lint = { golangci = true, missing = true } } })
+  end)
+  eq(calls, 0)
+  expect_error('options.integrations.nvim_lint.golangci must be boolean or table, got string', function()
+    helpers.call(lint_actions.setup, { integrations = { nvim_lint = { golangci = 'yes' } } })
+  end)
+end
+
 T['publish()'] = MiniTest.new_set()
 
 T['publish()']['treats an empty publication as a source clear'] = function()


### PR DESCRIPTION
Add a namespaced integrations option to setup(), allowing nvim-lint tools to be enabled with defaults or configured with tool-specific overrides.

Keep setup additive and idempotent, validate configuration before attaching integrations, and retain the direct attach APIs for lower-level use. Update the README and Vim help with the new configuration flow.