### PR TITLE
feat: supply actions through registered providers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,24 +1,35 @@
 # Architecture
 
-`lint-actions.nvim` connects fix producers to Neovim's existing LSP code-action UI.
+`lint-actions.nvim` connects fix sources to Neovim's existing LSP code-action UI.
 It makes structured fixes available to tools that already understand LSP code actions.
 It does not run linters or provide a picker for code actions.
 
+## Supplying actions
+
+A source reaches the code-action UI one of two ways, and the difference is
+when its actions are computed.
+
 ```mermaid
 flowchart LR
-    A["Linter or producer"] -->|raw output| B["Adapter"]
-    A -->|normalized actions| C["publish()"]
-    B -->|normalized actions| C
-    C --> D["Versioned action store"]
-    E["Neovim LSP UI<br/>built-in, fzf-lua, Telescope"] -->|textDocument/codeAction| F["In-process LSP transport"]
-    F -->|buffer, range, kind| D
-    D -->|fresh CodeActions| F
-    F -->|WorkspaceEdits| E
+    S["Linter or other source"]
+
+    subgraph pull["Pull — during a request"]
+        R["register()"] --> PR["Provider registry"]
+    end
+
+    subgraph push["Push — ahead of a request"]
+        A["Adapter"] -->|items| P["publish()"]
+        P --> ST[("Versioned action store")]
+    end
+
+    S -->|raw output| A
+    S -->|items| P
+    S -->|provide callback| R
 ```
 
 ## Publishing
 
-A producer can call `publish()` directly with normalized actions.
+A source can call `publish()` directly with normalized actions.
 Tool-specific adapters handle formats such as golangci-lint and markdownlint
 JSON, while integrations capture output another plugin already produced.
 The [nvim-lint](https://github.com/mfussenegger/nvim-lint) integration wraps its parser and never launches a second process.
@@ -32,23 +43,60 @@ same raw output to the selected adapter, then returns the diagnostics to
 nvim-lint unchanged.
 
 This also supports richer output formats than a bundled linter definition
-uses by default. The producer must switch the command arguments and parser as
+uses by default. The source must switch the command arguments and parser as
 one operation: for example, a `--json` argument must be paired with a JSON
 parser returning `vim.Diagnostic[]`. The adapter can then consume the JSON for
 fix metadata without disrupting nvim-lint's normal diagnostic flow.
 
-For same-buffer fixes, producers may put one `TextEdit` or a list of text edits in an action's `edit` field.
+That switch is a `configure` hook rather than something each integration does
+for itself, because nvim-lint resolves a linter either as a table or as a
+factory rebuilt on every run. The bridge owns that resolution once and calls
+`configure` on whichever definition it produces, immediately before wrapping
+the parser.
+
+For same-buffer fixes, a source may put one `TextEdit` or a list of text edits in an action's `edit` field.
 Publication wraps that shorthand in a versioned `WorkspaceEdit`, which is the type required by the LSP `CodeAction` protocol.
-Producers can instead supply a full `WorkspaceEdit` for multi-document changes or resource operations.
+A source can instead supply a full `WorkspaceEdit` for multi-document changes or resource operations.
 
 Actions are stored by buffer and source.
-Republishing replaces only that source, so several producers can coexist without coordinating with each other.
+Republishing replaces only that source, so several sources can coexist without coordinating with each other.
+`source` is that replacement key and nothing more: the LSP `CodeAction` type has no provenance field,
+and Neovim labels picker entries with the client name rather than anything a source chooses.
+
+## Providing
+
+Publication is a push: the source decides when its actions change and has to
+watch the buffer to know. That fits tools whose output arrives asynchronously,
+and it is the wrong shape for actions that are simply a function of buffer
+content.
+
+A registered provider is pulled instead. The transport asks it for actions
+inside the `textDocument/codeAction` request, so it computes against the
+current buffer and needs no autocmds, debouncing, or staleness handling. The
+cost is that `provide` runs on the request path and must be synchronous; a
+provider that raises is reported and skipped without failing the request.
+
+Both paths produce the same items and are matched by the same rule.
 
 ## Serving actions
 
-The first non-empty publication starts a small in-process LSP client.
-The same client is reused and attached only to buffers that publish actions.
-When Neovim requests `textDocument/codeAction`, the transport asks the store for actions matching the buffer, requested range, and optional action-kind filter.
+```mermaid
+flowchart LR
+    UI["Neovim LSP UI<br/>built-in, fzf-lua, Telescope"] -->|textDocument/codeAction| T["In-process LSP transport"]
+    T -->|buffer, range, kind| ST[("Versioned action store")]
+    T -->|buffer, range, kind| PR["Provider registry"]
+    ST -->|stored CodeActions| T
+    PR -->|CodeActions computed now| T
+    T -->|merged and sorted| UI
+    UI -->|applies WorkspaceEdit| B["Buffer"]
+```
+
+The first non-empty publication, or a provider that applies to a buffer,
+starts a small in-process LSP client.
+The same client is reused and attached only to buffers that publish actions or that a provider serves.
+When Neovim requests `textDocument/codeAction`, the transport asks the store and the registered providers
+for actions matching the buffer, requested range, and optional action-kind filter.
+Ranges are matched by line; an item without a range covers the whole buffer.
 
 The response contains ordinary `CodeAction` objects.
 Neovim and third-party pickers therefore handle selection, preview, and application through their normal LSP paths.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ its arguments and matching parser before attaching the bridge. See
 
 ## Publishing actions
 
+Actions belong to a source: a stable string naming whatever produced them. A
+source supplies its actions one of two ways. It can *push* them with
+`publish()`, which suits fixes that arrive from a tool when it finishes, or it
+can be *pulled* by registering a [provider](#providers), which suits actions
+derived from buffer content.
+
+`setup()` names bundled integrations only and rejects any other key, so a typo
+is reported rather than ignored. A third-party source is not registered there —
+it calls `publish()` or `register()` directly, and both call `setup()`
+themselves, so no ordering is required.
+
 Other tools can publish native actions directly:
 
 ```lua
@@ -112,6 +123,23 @@ lint_actions.publish({
   },
 })
 ```
+
+`source` is a replacement key, not provenance shown to the user. Republishing
+a source replaces only its own actions, so several sources coexist without
+coordinating. Neovim never displays it — its code-action UI labels an entry
+with the LSP client name, `lint-actions`, and only when more than one client is
+attached to the buffer.
+
+A source that wants to name itself does so in `action.title`, as a bracketed
+suffix matching that convention. The bundled golangci-lint adapter titles its
+actions `Apply suggested fix [errcheck]`, which renders as `Apply suggested fix
+[errcheck] [lint-actions]`. Prefer a suffix over a prefix: it stacks with
+Neovim's own label, and it leaves actions sorted by what they do rather than
+clustered under whoever produced them.
+
+An item's `range` says where the action is offered, and matching is
+line-granular — `character` is accepted for protocol shape but never narrows a
+match. Omit `range` to offer the action anywhere in the buffer.
 
 `action.edit` accepts one `lsp.TextEdit`, a list of text edits, or an
 `lsp.WorkspaceEdit`. A text edit only describes a range replacement, so
@@ -146,6 +174,50 @@ Both inputs are returned to Neovim as `CodeAction`s containing a
 either one. An opaque `command`, rather than the choice between `TextEdit` and
 `WorkspaceEdit`, is what normally prevents an edit preview. Neovim's built-in
 code-action selector applies edits but does not itself render a diff preview.
+
+An action may carry an `lsp.Command` instead of, or alongside, an edit, for a
+fix that cannot be expressed as a text edit. lint-actions returns it unchanged
+and Neovim resolves it client-side against `vim.lsp.commands`, so register the
+handler before publishing the action:
+
+```lua
+vim.lsp.commands['my-tool.run'] = function(command, context)
+  run(command.arguments[1], context.bufnr)
+end
+```
+
+lint-actions advertises no `executeCommandProvider`, so an unregistered name is
+not executed and warns instead. Prefer an edit wherever the fix can be
+expressed as one: edits are previewable, version-checked against the buffer,
+and undo as a single change.
+
+## Providers
+
+A provider is the pull half of the two ways above. Rather than deciding when
+its actions change and pushing them, it is asked for them when Neovim requests
+code actions — no autocmds, no debouncing, and nothing to keep fresh:
+
+```lua
+require('lint_actions').register({
+  source = 'my-tool',
+  filetypes = { 'lua' },
+  provide = function(context)
+    return {
+      {
+        action = {
+          title = 'Apply my fix',
+          kind = 'quickfix',
+          edit = { range = edit_range, newText = replacement },
+        },
+      },
+    }
+  end,
+})
+```
+
+`provide` runs inside the code-action request, so it must be synchronous and
+fast. A provider that raises is reported and skipped without affecting the
+rest of the request. See `:help lint-actions-providers`.
 
 See [the architecture note](ARCHITECTURE.md) for the data flow and stale-edit guarantees.
 

--- a/doc/lint-actions.txt
+++ b/doc/lint-actions.txt
@@ -5,14 +5,15 @@ CONTENTS                                                     *lint-actions-conte
 
 1. Introduction                                      |lint-actions-introduction|
 2. Setup                                                    |lint-actions-setup|
-3. Publishing                                              |lint-actions-publish|
-4. Integrations                                        |lint-actions-integrations|
-5. Health                                                    |lint-actions-health|
+3. Integrations                                        |lint-actions-integrations|
+4. Publishing                                              |lint-actions-publish|
+5. Providers                                             |lint-actions-providers|
+6. Health                                                    |lint-actions-health|
 
 ===============================================================================
 1. INTRODUCTION                                         *lint-actions-introduction*
 
-lint-actions.nvim exposes fixes from linters and other producers as ordinary
+lint-actions.nvim exposes fixes from linters and other sources as ordinary
 LSP code actions. It does not run tools or replace |vim.lsp.buf.code_action()|.
 
 Neovim 0.11 or newer is required.
@@ -48,43 +49,7 @@ Neovim 0.11 or newer is required.
     |lint-actions-integrations| for their requirements and options.
 
 ===============================================================================
-3. PUBLISHING                                                   *lint-actions-publish*
-
-                                                             *lint_actions.publish()*
-`publish({opts})`
-    Replaces the actions for one buffer and source. An empty `items` list
-    clears that source.
-
-    Fields: ~
-      bufnr   Buffer receiving the actions.
-      source  Stable producer identifier.
-      items   List of `{ range = lsp.Range, action = action }`. Each action is
-              an `lsp.CodeAction`, except its `edit` may also be one
-              `lsp.TextEdit` or a list of text edits targeting `bufnr`.
-
-    Same-buffer fixes should normally use the TextEdit shorthand: >lua
-
-      action = {
-        title = 'Apply suggested fix',
-        kind = 'quickfix',
-        edit = { range = edit_range, newText = replacement },
-      }
-<
-    `publish()` wraps text edits in a versioned `lsp.WorkspaceEdit`. Supply a
-    full WorkspaceEdit for multi-document edits or file operations. Both forms
-    remain declarative and can be diffed by preview-capable code-action UIs;
-    command-only actions generally cannot be previewed.
-
-                                                               *lint_actions.clear()*
-`clear({opts})`
-    Clears one source for a buffer. Omit `source` to clear all sources.
-
-                                                              *lint_actions.ingest()*
-`ingest({opts})`
-    Parses tool output with `opts.adapter` and publishes the returned items.
-
-===============================================================================
-4. INTEGRATIONS             *lint-actions-integrations* *lint-actions-adapters*
+3. INTEGRATIONS             *lint-actions-integrations* *lint-actions-adapters*
 
 Bundled integrations reuse output from nvim-lint and do not launch a second
 linter process. Supported tools and their setup guides are: ~
@@ -114,12 +79,14 @@ users can connect it to a compatible adapter: >lua
     linter = 'linter-name',
     adapter = require('my_adapter'),
     source = 'optional-source-override',
+    configure = optional_function,
   })
 <
 `linter` accepts a registered nvim-lint name or a concrete linter definition.
 The adapter must expose `source` and `parse(context)`. The integration wraps
 the existing parser, preserves its diagnostics, and passes the same process
-output to the adapter. It does not change the linter command or arguments.
+output to the adapter. On its own it does not change the linter command or
+arguments; `configure` is how an integration changes them.
 
 CHANGING THE OUTPUT FORMAT ~
 
@@ -146,6 +113,27 @@ The replacement parser must accept `(output, bufnr, cwd)` and return
 Changing only the output argument would leave the old parser reading the
 wrong format and break diagnostics. Changing the argument and parser together
 keeps nvim-lint diagnostics working while exposing richer data to the adapter.
+
+Doing it by hand only works for a concrete linter definition. A linter
+registered as a factory is rebuilt on every run, so its arguments have to be
+set each time one is produced. Pass `configure` instead and the integration
+applies it wherever the linter is resolved from: >lua
+
+  require('lint_actions.integrations.nvim_lint').attach({
+    linter = 'my_linter',
+    adapter = adapter,
+    configure = function(linter)
+      linter.args = linter.args or {}
+      table.insert(linter.args, '--json')
+      linter.parser = adapter.diagnostics
+    end,
+  })
+<
+`configure` receives the resolved linter before its parser is wrapped, and
+runs once per linter. Because it must run before the wrap, attaching a linter
+through a plain `attach()` first and adding a `configure` afterwards raises an
+error rather than silently leaving the arguments unchanged.
+
 The markdownlint integration, |lint-actions-markdownlint|, is a complete
 example of this pattern.
 
@@ -154,7 +142,151 @@ Producers that already have normalized actions can bypass nvim-lint and use
 with |lint_actions.ingest()|.
 
 ===============================================================================
-5. HEALTH                                                         *lint-actions-health*
+4. PUBLISHING                                                   *lint-actions-publish*
+
+Actions belong to a source: a stable string naming whatever produced them. A
+source supplies its actions one of two ways. It can push them with `publish()`,
+which suits fixes that arrive from a tool when it finishes, or it can be pulled
+by registering a provider, which suits actions derived from buffer content and
+is described in |lint-actions-providers|.
+
+`source` is a replacement key, not provenance shown to the user. Republishing
+a source replaces only its own actions, so several sources coexist without
+coordinating. Neovim never displays it: its code-action UI labels an entry with
+the LSP client name, `lint-actions`, and only when more than one client is
+attached to the buffer.
+
+A source that wants to name itself does so in `action.title`, as a bracketed
+suffix matching that convention. The bundled golangci-lint adapter titles its
+actions `Apply suggested fix [errcheck]`, which reaches the picker as
+`Apply suggested fix [errcheck] [lint-actions]`. Prefer a suffix over a
+prefix: it stacks with Neovim's own label, and it leaves actions sorted by
+what they do rather than clustered under whoever produced them.
+
+                                                             *lint_actions.publish()*
+`publish({opts})`
+    Replaces the actions for one buffer and source. An empty `items` list
+    clears that source.
+
+    Fields: ~
+      bufnr   Buffer receiving the actions.
+      source  Stable identifier for whatever produced the actions.
+      items   List of `{ range = range, action = action }`. Each action is
+              an `lsp.CodeAction`, except its `edit` may also be one
+              `lsp.TextEdit` or a list of text edits targeting `bufnr`.
+
+    An item's `range` says where the action is offered. Matching is
+    line-granular: `character` is accepted for protocol shape but never
+    narrows a match. Omit `range` entirely to offer the action anywhere in
+    the buffer.
+
+    Same-buffer fixes should normally use the TextEdit shorthand: >lua
+
+      action = {
+        title = 'Apply suggested fix',
+        kind = 'quickfix',
+        edit = { range = edit_range, newText = replacement },
+      }
+<
+    `publish()` wraps text edits in a versioned `lsp.WorkspaceEdit`. Supply a
+    full WorkspaceEdit for multi-document edits or file operations. Both forms
+    remain declarative and can be diffed by preview-capable code-action UIs;
+    command-only actions generally cannot be previewed.
+
+ACTIONS THAT ARE NOT EDITS ~
+
+    An action may carry an `lsp.Command` instead of, or alongside, an edit,
+    for a fix that cannot be expressed as a text edit. lint-actions returns it
+    unchanged and Neovim resolves it client-side, so register the handler
+    before publishing the action: >lua
+
+      vim.lsp.commands['my-tool.run'] = function(command, context)
+        run(command.arguments[1], context.bufnr)
+      end
+<
+    Neovim looks the name up in `vim.lsp.commands` (and in the client's own
+    command table) before asking the server. lint-actions advertises no
+    `executeCommandProvider`, so an unregistered name is not executed and
+    warns that the server does not support the command. Prefer an edit
+    wherever the fix can be expressed as one: edits are previewable, are
+    version-checked against the buffer, and undo as a single change.
+
+                                                               *lint_actions.clear()*
+`clear({opts})`
+    Clears one source for a buffer. Omit `source` to clear all sources.
+
+                                                              *lint_actions.ingest()*
+`ingest({opts})`
+    Parses tool output with `opts.adapter` and publishes the returned items.
+
+===============================================================================
+5. PROVIDERS                                                  *lint-actions-providers*
+
+`setup()` names bundled integrations only, and rejects any other key so a
+typo is reported rather than silently ignored. A third-party source does not
+register itself there: it calls |lint_actions.publish()| or
+|lint_actions.register()| directly. Both call `setup()` themselves, so no
+ordering between them is required.
+
+A provider is the pull half of |lint-actions-publish|. Rather than deciding
+when its actions change and pushing them, it is asked for them when Neovim
+requests code actions. It needs no autocmds, no debouncing, and no staleness
+handling, because it computes against the current buffer.
+
+                                                            *lint_actions.register()*
+`register({provider})`
+    Registers a provider. Registering the same `source` again replaces the
+    earlier provider.
+
+    Fields: ~
+      source     Stable identifier for whatever produced the actions.
+      provide    `fun(context): items`. Called synchronously for each request.
+                 May return `nil` for no actions. `context` carries `bufnr`,
+                 the requested `range`, and `only` when the client filtered by
+                 kind. Returned items are matched against the request the same
+                 way published items are.
+      filetypes  Optional list restricting the provider to those filetypes.
+      enabled    Optional `fun(bufnr): boolean` restricting it further.
+
+    Example: >lua
+
+      require('lint_actions').register({
+        source = 'my-tool',
+        filetypes = { 'lua' },
+        provide = function(context)
+          if not needs_fix(context.bufnr) then
+            return {}
+          end
+          return {
+            {
+              action = {
+                title = 'Apply my fix',
+                kind = 'quickfix',
+                edit = { range = edit_range, newText = replacement },
+              },
+            },
+          }
+        end,
+      })
+<
+    Providers run inside the `textDocument/codeAction` request, so `provide`
+    must be synchronous and fast; a slow provider delays the action picker.
+    Producers whose fixes come from a process should publish instead.
+
+    A provider that raises is reported with |vim.notify()| and skipped. Other
+    providers and published actions still answer the same request.
+
+    Registering a provider attaches the in-process client to ordinary file
+    buffers (`buftype` is empty) that the provider applies to, including
+    buffers already open. Declaring `filetypes` keeps that attachment narrow.
+
+                                                          *lint_actions.unregister()*
+`unregister({source})`
+    Removes a provider. Buffers stay attached and simply stop receiving
+    actions from that source.
+
+===============================================================================
+6. HEALTH                                                         *lint-actions-health*
 
 Run `:checkhealth lint_actions` to check the Neovim requirement.
 

--- a/lua/lint_actions/init.lua
+++ b/lua/lint_actions/init.lua
@@ -1,3 +1,5 @@
+local items = require('lint_actions.items')
+
 local M = {}
 
 local configured = false
@@ -8,82 +10,9 @@ local integration_modules = {
   },
 }
 
-local function expect(value, expected, name)
-  if type(value) ~= expected then
-    error(('%s must be %s, got %s'):format(name, expected, type(value)), 3)
-  end
-end
-
-local function validate_position(position, name)
-  expect(position, 'table', name)
-  expect(position.line, 'number', name .. '.line')
-  expect(position.character, 'number', name .. '.character')
-end
-
----@param items LintActions.Item[]
-local function validate_items(items)
-  expect(items, 'table', 'items')
-  for index, item in ipairs(items) do
-    local name = ('items[%d]'):format(index)
-    expect(item, 'table', name)
-    expect(item.range, 'table', name .. '.range')
-    validate_position(item.range.start, name .. '.range.start')
-    validate_position(item.range['end'], name .. '.range.end')
-    expect(item.action, 'table', name .. '.action')
-    expect(item.action.title, 'string', name .. '.action.title')
-  end
-end
-
----@param action lsp.CodeAction
----@param uri string
----@param version integer
----@return lsp.CodeAction
-local function version_edit(action, uri, version)
-  action = vim.deepcopy(action)
-  local edit = action.edit
-  if not edit then
-    return action
-  end
-
-  -- Text edits do not identify their target document. Accept one edit or a
-  -- list as a convenient same-buffer shorthand, then put the protocol-correct
-  -- WorkspaceEdit on the CodeAction returned to Neovim.
-  local text_edit_range = rawget(edit, 'range')
-  if text_edit_range or vim.islist(edit) then
-    local edits = text_edit_range and { edit } or edit
-    action.edit = {
-      documentChanges = {
-        {
-          textDocument = { uri = uri, version = version },
-          edits = edits,
-        },
-      },
-    }
-    return action
-  end
-
-  if edit.changes then
-    edit.documentChanges = edit.documentChanges or {}
-    for edit_uri, edits in pairs(edit.changes) do
-      table.insert(edit.documentChanges, {
-        textDocument = { uri = edit_uri, version = edit_uri == uri and version or nil },
-        edits = edits,
-      })
-    end
-    edit.changes = nil
-  end
-
-  for _, change in ipairs(edit.documentChanges or {}) do
-    if change.textDocument and change.textDocument.uri == uri then
-      change.textDocument.version = version
-    end
-  end
-  return action
-end
-
 ---@param integrations table<string, boolean|table>
 local function validate_integrations(integrations)
-  expect(integrations, 'table', 'options.integrations')
+  items.expect(integrations, 'table', 'options.integrations')
 
   for integration, tools in pairs(integrations) do
     local modules = integration_modules[integration]
@@ -132,7 +61,7 @@ function M.setup(options)
   if options == nil then
     options = {}
   end
-  expect(options, 'table', 'options')
+  items.expect(options, 'table', 'options')
   for name in pairs(options) do
     if name ~= 'integrations' then
       error(('unknown setup option: %s'):format(name), 2)
@@ -162,10 +91,13 @@ end
 ---An empty item list clears that source without starting the LSP client.
 ---@param options LintActions.PublishOptions
 function M.publish(options)
-  expect(options, 'table', 'options')
-  expect(options.bufnr, 'number', 'bufnr')
-  expect(options.source, 'string', 'source')
-  validate_items(options.items)
+  items.expect(options, 'table', 'options')
+  items.expect(options.bufnr, 'number', 'bufnr')
+  items.expect(options.source, 'string', 'source')
+  local valid, invalid = pcall(items.validate, options.items)
+  if not valid then
+    error(invalid, 2)
+  end
   if options.source == '' then
     error('source must not be empty', 2)
   end
@@ -180,45 +112,65 @@ function M.publish(options)
   end
   require('lint_actions.server').attach(options.bufnr)
 
-  local uri = vim.uri_from_bufnr(options.bufnr)
-  local version = vim.lsp.util.buf_versions[options.bufnr]
-  local changedtick = vim.api.nvim_buf_get_changedtick(options.bufnr)
-  local items = vim.tbl_map(function(item)
-    return {
-      range = vim.deepcopy(item.range),
-      action = version_edit(item.action, uri, changedtick),
-    }
-  end, options.items)
-
   require('lint_actions.store').publish({
     bufnr = options.bufnr,
-    uri = uri,
+    uri = vim.uri_from_bufnr(options.bufnr),
     source = options.source,
-    changedtick = changedtick,
-    version = version,
-    items = items,
+    changedtick = vim.api.nvim_buf_get_changedtick(options.bufnr),
+    version = vim.lsp.util.buf_versions[options.bufnr],
+    items = items.normalize(options.items, options.bufnr),
   })
 end
 
 ---Clear actions for one source, or every source when `source` is omitted.
 ---@param options LintActions.ClearOptions
 function M.clear(options)
-  expect(options, 'table', 'options')
-  expect(options.bufnr, 'number', 'bufnr')
+  items.expect(options, 'table', 'options')
+  items.expect(options.bufnr, 'number', 'bufnr')
   if options.source ~= nil then
-    expect(options.source, 'string', 'source')
+    items.expect(options.source, 'string', 'source')
   end
   require('lint_actions.store').clear(options.bufnr, options.source)
+end
+
+---Register a provider that is asked for actions when Neovim requests them,
+---instead of publishing them ahead of time. Registering the same source twice
+---replaces the earlier provider.
+---@param provider LintActions.Provider
+function M.register(provider)
+  items.expect(provider, 'table', 'provider')
+  items.expect(provider.source, 'string', 'provider.source')
+  items.expect(provider.provide, 'function', 'provider.provide')
+  if provider.source == '' then
+    error('provider.source must not be empty', 2)
+  end
+  if provider.filetypes ~= nil then
+    items.expect(provider.filetypes, 'table', 'provider.filetypes')
+  end
+  if provider.enabled ~= nil then
+    items.expect(provider.enabled, 'function', 'provider.enabled')
+  end
+
+  M.setup()
+  require('lint_actions.providers').register(provider)
+end
+
+---Remove a registered provider. Buffers stay attached; they simply stop
+---receiving actions from that source.
+---@param source string
+function M.unregister(source)
+  items.expect(source, 'string', 'source')
+  require('lint_actions.providers').unregister(source)
 end
 
 ---Parse tool output through an adapter and publish the resulting actions.
 ---@param options LintActions.IngestOptions
 function M.ingest(options)
-  expect(options, 'table', 'options')
-  expect(options.adapter, 'table', 'adapter')
-  expect(options.adapter.parse, 'function', 'adapter.parse')
+  items.expect(options, 'table', 'options')
+  items.expect(options.adapter, 'table', 'adapter')
+  items.expect(options.adapter.parse, 'function', 'adapter.parse')
 
-  local items = options.adapter.parse({
+  local parsed = options.adapter.parse({
     output = options.output,
     bufnr = options.bufnr,
     cwd = options.cwd,
@@ -227,7 +179,7 @@ function M.ingest(options)
   return M.publish({
     bufnr = options.bufnr,
     source = options.source or options.adapter.source,
-    items = items,
+    items = parsed,
   })
 end
 

--- a/lua/lint_actions/integrations/golangci.lua
+++ b/lua/lint_actions/integrations/golangci.lua
@@ -1,4 +1,5 @@
 local adapter = require('lint_actions.adapters.golangci')
+local items = require('lint_actions.items')
 local nvim_lint = require('lint_actions.integrations.nvim_lint')
 
 local M = {}
@@ -14,7 +15,7 @@ function M.attach(options)
   if options == nil then
     options = {}
   end
-  vim.validate('options', options, 'table')
+  items.expect(options, 'table', 'options')
 
   local linter = options.linter
   if linter == nil then

--- a/lua/lint_actions/integrations/markdownlint.lua
+++ b/lua/lint_actions/integrations/markdownlint.lua
@@ -1,36 +1,26 @@
 local adapter = require('lint_actions.adapters.markdownlint')
+local items = require('lint_actions.items')
 local nvim_lint = require('lint_actions.integrations.nvim_lint')
 
 local M = {}
-local wrapped_factories = setmetatable({}, { __mode = 'k' })
-
----@class LintActions.MarkdownlintLinter : LintActions.NvimLintLinter
----@field _lint_actions_markdownlint_attached? boolean
 
 ---@class LintActions.MarkdownlintOptions
----@field linter? string|LintActions.MarkdownlintLinter Defaults to `markdownlint`.
+---@field linter? string|LintActions.NvimLintLinter Defaults to `markdownlint`.
 ---@field source? string Overrides the adapter's source.
 
----@param linter LintActions.MarkdownlintLinter
----@param source string
-local function configure(linter, source)
-  if linter._lint_actions_markdownlint_attached then
-    return
-  end
-  if linter._lint_actions_attached then
-    error('attach the markdownlint integration before attaching this linter through nvim_lint')
-  end
+---markdownlint only reports fix metadata in its JSON output, so the linter has
+---to run with `--json` and parse it before its output is worth adapting.
+---@param linter LintActions.NvimLintLinter
+local function configure(linter)
   if linter.args ~= nil and type(linter.args) ~= 'table' then
     error('markdownlint linter args must be a table')
   end
 
-  linter._lint_actions_markdownlint_attached = true
   linter.args = linter.args or {}
   if not vim.tbl_contains(linter.args, '--json') then
     table.insert(linter.args, '--json')
   end
   linter.parser = adapter.diagnostics
-  nvim_lint.attach({ linter = linter, adapter = adapter, source = source })
 end
 
 ---Configure markdownlint for JSON output and publish fixes from that output.
@@ -40,42 +30,23 @@ function M.attach(options)
   if options == nil then
     options = {}
   end
-  vim.validate('options', options, 'table')
+  items.expect(options, 'table', 'options')
 
+  local linter = options.linter
+  if linter == nil then
+    linter = 'markdownlint'
+  end
   local source = options.source
   if source == nil then
     source = adapter.source
   end
-  vim.validate('source', source, 'string')
-  local linter_option = options.linter
-  if linter_option == nil then
-    linter_option = 'markdownlint'
-  end
-  if type(linter_option) == 'string' then
-    local lint = require('lint')
-    local linter = lint.linters[linter_option]
-    if type(linter) == 'function' then
-      if wrapped_factories[linter] then
-        return
-      end
-      local factory = function()
-        local definition = linter()
-        vim.validate('linter definition', definition, 'table')
-        configure(definition, source)
-        return definition
-      end
-      wrapped_factories[factory] = true
-      lint.linters[linter_option] = factory
-    elseif type(linter) == 'table' then
-      configure(linter, source)
-    else
-      error(('unknown nvim-lint linter: %s'):format(linter_option))
-    end
-  elseif type(linter_option) == 'table' then
-    configure(linter_option, source)
-  else
-    error('options.linter must be a linter name or table')
-  end
+
+  return nvim_lint.attach({
+    linter = linter,
+    adapter = adapter,
+    source = source,
+    configure = configure,
+  })
 end
 
 return M

--- a/lua/lint_actions/integrations/nvim_lint.lua
+++ b/lua/lint_actions/integrations/nvim_lint.lua
@@ -1,3 +1,5 @@
+local items = require('lint_actions.items')
+
 local M = {}
 local wrapped_factories = setmetatable({}, { __mode = 'k' })
 
@@ -6,25 +8,37 @@ local wrapped_factories = setmetatable({}, { __mode = 'k' })
 ---@class LintActions.NvimLintLinter
 ---@field parser LintActions.NvimLintParser
 ---@field args? (string|fun(): string)[]
----@field _lint_actions_attached? boolean
+---@field _lint_actions_attached? string Source that wrapped this linter.
+
+---@alias LintActions.NvimLintConfigure fun(linter: LintActions.NvimLintLinter)
 
 ---@class LintActions.NvimLintOptions
 ---@field linter string|LintActions.NvimLintLinter nvim-lint linter name or concrete definition.
 ---@field adapter LintActions.Adapter
 ---@field source? string Overrides the adapter's source.
+---@field configure? LintActions.NvimLintConfigure Prepares the resolved linter before its parser is wrapped.
 
 ---@param linter LintActions.NvimLintLinter
 ---@param adapter LintActions.Adapter
 ---@param source string
-local function attach(linter, adapter, source)
+---@param configure? LintActions.NvimLintConfigure
+local function attach(linter, adapter, source, configure)
   if linter._lint_actions_attached then
+    -- The linter's arguments and parser are already wrapped, so a late
+    -- configure step could no longer take effect on the running command.
+    if configure and linter._lint_actions_attached ~= source then
+      error('attach the ' .. source .. ' integration before attaching this linter through nvim_lint')
+    end
     return
+  end
+  if configure then
+    configure(linter)
   end
   if type(linter.parser) ~= 'function' then
     error('lint-actions only supports nvim-lint parser functions')
   end
 
-  linter._lint_actions_attached = true
+  linter._lint_actions_attached = source
   local parse = linter.parser
   linter.parser = function(output, bufnr, cwd)
     local diagnostics = parse(output, bufnr, cwd)
@@ -58,15 +72,18 @@ end
 ---The parser's diagnostics and return value are preserved.
 ---@param options LintActions.NvimLintOptions
 function M.attach(options)
-  vim.validate('options', options, 'table')
-  vim.validate('options.adapter', options.adapter, 'table')
-  vim.validate('options.adapter.parse', options.adapter.parse, 'function')
+  items.expect(options, 'table', 'options')
+  items.expect(options.adapter, 'table', 'options.adapter')
+  items.expect(options.adapter.parse, 'function', 'options.adapter.parse')
+  if options.configure ~= nil then
+    items.expect(options.configure, 'function', 'options.configure')
+  end
 
   local source = options.source
   if source == nil then
     source = options.adapter.source
   end
-  vim.validate('source', source, 'string')
+  items.expect(source, 'string', 'source')
   local linter_option = options.linter
   if type(linter_option) == 'string' then
     local lint = require('lint')
@@ -77,19 +94,19 @@ function M.attach(options)
       end
       local factory = function()
         local definition = linter()
-        vim.validate('linter definition', definition, 'table')
-        attach(definition, options.adapter, source)
+        items.expect(definition, 'table', 'linter definition', 0)
+        attach(definition, options.adapter, source, options.configure)
         return definition
       end
       wrapped_factories[factory] = true
       lint.linters[linter_option] = factory
     elseif type(linter) == 'table' then
-      attach(linter, options.adapter, source)
+      attach(linter, options.adapter, source, options.configure)
     else
       error(('unknown nvim-lint linter: %s'):format(linter_option))
     end
   elseif type(linter_option) == 'table' then
-    attach(linter_option, options.adapter, source)
+    attach(linter_option, options.adapter, source, options.configure)
   else
     error('options.linter must be a linter name or table')
   end

--- a/lua/lint_actions/items.lua
+++ b/lua/lint_actions/items.lua
@@ -1,0 +1,170 @@
+local M = {}
+
+---Raise a type error. `level` follows `error()` and defaults to the caller of
+---the function doing the validation, which is right when a public entry point
+---checks its own arguments. Pass 0 to raise the bare message instead, for a
+---caller that re-raises it at its own call site.
+---@param value any
+---@param expected string
+---@param name string
+---@param level? integer
+function M.expect(value, expected, name, level)
+  if type(value) ~= expected then
+    error(('%s must be %s, got %s'):format(name, expected, type(value)), level or 3)
+  end
+end
+
+---@param position LintActions.Position
+---@param name string
+local function validate_position(position, name)
+  M.expect(position, 'table', name, 0)
+  M.expect(position.line, 'number', name .. '.line', 0)
+  if position.character ~= nil then
+    M.expect(position.character, 'number', name .. '.character', 0)
+  end
+end
+
+---Validate items supplied by a source. Raises the bare message; callers re-raise.
+---@param items LintActions.Item[]
+function M.validate(items)
+  M.expect(items, 'table', 'items', 0)
+  for index, item in ipairs(items) do
+    local name = ('items[%d]'):format(index)
+    M.expect(item, 'table', name, 0)
+    if item.range ~= nil then
+      M.expect(item.range, 'table', name .. '.range', 0)
+      validate_position(item.range.start, name .. '.range.start')
+      validate_position(item.range['end'], name .. '.range.end')
+    end
+    M.expect(item.action, 'table', name .. '.action', 0)
+    M.expect(item.action.title, 'string', name .. '.action.title', 0)
+  end
+end
+
+---@param bufnr integer
+---@return lsp.Range
+local function buffer_range(bufnr)
+  local last_line = math.max(vim.api.nvim_buf_line_count(bufnr) - 1, 0)
+  return { start = { line = 0, character = 0 }, ['end'] = { line = last_line, character = 0 } }
+end
+
+---@param range? LintActions.Range
+---@param bufnr integer
+---@return lsp.Range
+local function normalize_range(range, bufnr)
+  if range == nil then
+    return buffer_range(bufnr)
+  end
+  return {
+    start = { line = range.start.line, character = range.start.character or 0 },
+    ['end'] = { line = range['end'].line, character = range['end'].character or 0 },
+  }
+end
+
+---@param action lsp.CodeAction
+---@param uri string
+---@param version integer
+---@return lsp.CodeAction
+local function version_edit(action, uri, version)
+  action = vim.deepcopy(action)
+  local edit = action.edit
+  if not edit then
+    return action
+  end
+
+  -- Text edits do not identify their target document. Accept one edit or a
+  -- list as a convenient same-buffer shorthand, then put the protocol-correct
+  -- WorkspaceEdit on the CodeAction returned to Neovim.
+  local text_edit_range = rawget(edit, 'range')
+  if text_edit_range or vim.islist(edit) then
+    local edits = text_edit_range and { edit } or edit
+    action.edit = {
+      documentChanges = {
+        {
+          textDocument = { uri = uri, version = version },
+          edits = edits,
+        },
+      },
+    }
+    return action
+  end
+
+  if edit.changes then
+    edit.documentChanges = edit.documentChanges or {}
+    for edit_uri, edits in pairs(edit.changes) do
+      table.insert(edit.documentChanges, {
+        textDocument = { uri = edit_uri, version = edit_uri == uri and version or nil },
+        edits = edits,
+      })
+    end
+    edit.changes = nil
+  end
+
+  for _, change in ipairs(edit.documentChanges or {}) do
+    if change.textDocument and change.textDocument.uri == uri then
+      change.textDocument.version = version
+    end
+  end
+  return action
+end
+
+---Copy validated items, filling in the default range and versioning edits
+---against the buffer's current changed tick.
+---@param items LintActions.Item[]
+---@param bufnr integer
+---@return LintActions.NormalizedItem[]
+function M.normalize(items, bufnr)
+  local uri = vim.uri_from_bufnr(bufnr)
+  local version = vim.api.nvim_buf_get_changedtick(bufnr)
+  return vim.tbl_map(function(item)
+    return {
+      range = normalize_range(item.range, bufnr),
+      action = version_edit(item.action, uri, version),
+    }
+  end, items)
+end
+
+---@param left lsp.Range
+---@param right lsp.Range
+local function ranges_overlap(left, right)
+  return left.start.line <= right['end'].line and right.start.line <= left['end'].line
+end
+
+---@param kind? lsp.CodeActionKind
+---@param only? lsp.CodeActionKind[]
+local function kind_matches(kind, only)
+  if not only or #only == 0 then
+    return true
+  end
+  if not kind then
+    return false
+  end
+
+  for _, requested in ipairs(only) do
+    if kind == requested or vim.startswith(kind, requested .. '.') then
+      return true
+    end
+  end
+  return false
+end
+
+---Decide whether an item answers a code-action request. Ranges are matched by
+---line; `character` is accepted for protocol shape but never narrows a match.
+---@param item LintActions.NormalizedItem
+---@param range lsp.Range
+---@param only? lsp.CodeActionKind[]
+---@return boolean
+function M.matches(item, range, only)
+  return ranges_overlap(item.range, range) and kind_matches(item.action.kind, only)
+end
+
+---@param actions lsp.CodeAction[]
+---@return lsp.CodeAction[]
+function M.sort(actions)
+  table.sort(actions, function(left, right)
+    return left.title < right.title
+  end)
+  return actions
+end
+
+return M

--- a/lua/lint_actions/providers.lua
+++ b/lua/lint_actions/providers.lua
@@ -1,0 +1,143 @@
+local items = require('lint_actions.items')
+
+local M = {}
+
+---@type table<string, LintActions.Provider>
+local providers = {}
+local group
+
+---@param source string
+---@param err string
+local function report(source, err)
+  vim.schedule(function()
+    vim.notify(('lint-actions: provider %s: %s'):format(source, err), vim.log.levels.ERROR)
+  end)
+end
+
+---A provider serves ordinary file buffers. Anything else is left alone so the
+---client is not attached to scratch, terminal, or plugin buffers.
+---@param bufnr integer
+---@return boolean
+local function eligible(bufnr)
+  return vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr) and vim.bo[bufnr].buftype == ''
+end
+
+---@param provider LintActions.Provider
+---@param bufnr integer
+---@return boolean
+local function applies(provider, bufnr)
+  if provider.filetypes and not vim.tbl_contains(provider.filetypes, vim.bo[bufnr].filetype) then
+    return false
+  end
+  if not provider.enabled then
+    return true
+  end
+
+  local ok, enabled = pcall(provider.enabled, bufnr)
+  if not ok then
+    report(provider.source, tostring(enabled))
+    return false
+  end
+  return enabled and true or false
+end
+
+---Run one provider, keeping its failures out of the rest of the request.
+---@param provider LintActions.Provider
+---@param context LintActions.ProviderContext
+---@return LintActions.NormalizedItem[]? items
+---@return string? err
+local function collect(provider, context)
+  local ok, produced = pcall(provider.provide, context)
+  if not ok then
+    return nil, tostring(produced)
+  end
+
+  ---@type LintActions.Item[]
+  local candidates = produced or {}
+  local valid, invalid = pcall(items.validate, candidates)
+  if not valid then
+    return nil, tostring(invalid)
+  end
+  return items.normalize(candidates, context.bufnr)
+end
+
+---@param bufnr integer
+local function attach(bufnr)
+  if not eligible(bufnr) then
+    return
+  end
+  for _, provider in pairs(providers) do
+    if applies(provider, bufnr) then
+      require('lint_actions.server').attach(bufnr)
+      return
+    end
+  end
+end
+
+---Replace the provider registered under a source.
+---@param provider LintActions.Provider
+function M.register(provider)
+  providers[provider.source] = provider
+
+  if not group then
+    group = vim.api.nvim_create_augroup('lint_actions_providers', { clear = true })
+    vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile', 'FileType' }, {
+      group = group,
+      desc = 'attach lint-actions to buffers a provider serves',
+      callback = function(event)
+        attach(event.buf)
+      end,
+    })
+  end
+
+  -- Registration usually happens after startup, so buffers that are already
+  -- open would otherwise never see the client.
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    attach(bufnr)
+  end
+end
+
+---@param source string
+function M.unregister(source)
+  providers[source] = nil
+end
+
+---Ask every applicable provider for actions matching a request.
+---@param bufnr integer
+---@param range lsp.Range
+---@param only? lsp.CodeActionKind[]
+---@return lsp.CodeAction[]
+function M.actions(bufnr, range, only)
+  local actions = {}
+  if not eligible(bufnr) then
+    return actions
+  end
+
+  local sources = vim.tbl_keys(providers)
+  table.sort(sources)
+
+  for _, source in ipairs(sources) do
+    local provider = providers[source]
+    if applies(provider, bufnr) then
+      local produced, err = collect(provider, { bufnr = bufnr, range = range, only = only })
+      if not produced then
+        report(source, err or 'provider failed')
+      else
+        for _, item in ipairs(produced) do
+          if items.matches(item, range, only) then
+            table.insert(actions, item.action)
+          end
+        end
+      end
+    end
+  end
+
+  return actions
+end
+
+---Reset all state. Intended for tests.
+function M._reset()
+  providers = {}
+end
+
+return M

--- a/lua/lint_actions/server.lua
+++ b/lua/lint_actions/server.lua
@@ -1,3 +1,5 @@
+local items = require('lint_actions.items')
+local providers = require('lint_actions.providers')
 local store = require('lint_actions.store')
 
 local M = {}
@@ -35,7 +37,12 @@ local function cmd(dispatchers)
     elseif method == 'textDocument/codeAction' then
       local bufnr = vim.uri_to_bufnr(params.textDocument.uri)
       local only = params.context and params.context.only or nil
-      local actions = vim.api.nvim_buf_is_valid(bufnr) and store.actions(bufnr, params.range, only) or {}
+      local actions = {}
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        actions = store.actions(bufnr, params.range, only)
+        vim.list_extend(actions, providers.actions(bufnr, params.range, only))
+        items.sort(actions)
+      end
       callback(nil, actions)
     elseif method == 'shutdown' then
       callback(nil, nil)

--- a/lua/lint_actions/store.lua
+++ b/lua/lint_actions/store.lua
@@ -1,26 +1,8 @@
+local items = require('lint_actions.items')
+
 local M = {}
 
 local batches = {}
-
-local function ranges_overlap(left, right)
-  return left.start.line <= right['end'].line and right.start.line <= left['end'].line
-end
-
-local function kind_matches(kind, only)
-  if not only or #only == 0 then
-    return true
-  end
-  if not kind then
-    return false
-  end
-
-  for _, requested in ipairs(only) do
-    if kind == requested or vim.startswith(kind, requested .. '.') then
-      return true
-    end
-  end
-  return false
-end
 
 ---Replace a source's current batch.
 ---@param batch LintActions.Batch
@@ -62,7 +44,7 @@ function M.actions(bufnr, range, only)
   for source, batch in pairs(batches[bufnr] or {}) do
     if batch.changedtick == changedtick and batch.version == version then
       for _, item in ipairs(batch.items) do
-        if ranges_overlap(item.range, range) and kind_matches(item.action.kind, only) then
+        if items.matches(item, range, only) then
           table.insert(actions, vim.deepcopy(item.action))
         end
       end
@@ -75,10 +57,7 @@ function M.actions(bufnr, range, only)
     M.clear(bufnr, source)
   end
 
-  table.sort(actions, function(left, right)
-    return left.title < right.title
-  end)
-  return actions
+  return items.sort(actions)
 end
 
 ---Reset all state. Intended for tests.

--- a/lua/lint_actions/types.lua
+++ b/lua/lint_actions/types.lua
@@ -1,5 +1,13 @@
 ---@alias LintActions.Edit lsp.TextEdit|lsp.TextEdit[]|lsp.WorkspaceEdit
 
+---@class LintActions.Position
+---@field line integer Zero-based line.
+---@field character? integer Accepted for protocol shape; matching is line-granular.
+
+---@class LintActions.Range
+---@field start LintActions.Position
+---@field end LintActions.Position
+
 ---@class LintActions.NvimLintIntegrationOptions
 ---@field golangci? boolean|LintActions.GolangciOptions Enable with defaults using `true`, or pass integration options.
 ---@field markdownlint? boolean|LintActions.MarkdownlintOptions Enable with defaults using `true`, or pass integration options.
@@ -14,12 +22,27 @@
 ---@field edit? LintActions.Edit A TextEdit or list targets the published buffer; a WorkspaceEdit may target multiple resources.
 
 ---@class LintActions.Item
----@field range lsp.Range Range in which the action is offered.
+---@field range? LintActions.Range Lines on which the action is offered. Omit for the whole buffer.
 ---@field action LintActions.CodeAction Action returned to the LSP client.
+
+---@class LintActions.NormalizedItem
+---@field range lsp.Range Range filled in by `normalize()`.
+---@field action lsp.CodeAction Action with its edit already versioned.
+
+---@class LintActions.ProviderContext
+---@field bufnr integer Buffer the request is for.
+---@field range lsp.Range Range Neovim asked about.
+---@field only? lsp.CodeActionKind[] Requested kinds, when the client filtered.
+
+---@class LintActions.Provider
+---@field source string Stable identifier for whatever produced the actions. Replacement key, not shown in the picker.
+---@field provide fun(context: LintActions.ProviderContext): LintActions.Item[]? Called synchronously per request.
+---@field filetypes? string[] Restrict the provider to these filetypes.
+---@field enabled? fun(bufnr: integer): boolean Further restrict the provider per buffer.
 
 ---@class LintActions.PublishOptions
 ---@field bufnr integer
----@field source string Stable identifier for the action producer.
+---@field source string Stable identifier for whatever produced the actions. Replacement key, not shown in the picker.
 ---@field items LintActions.Item[]
 
 ---@class LintActions.ClearOptions
@@ -46,6 +69,6 @@
 ---@field source string
 ---@field changedtick integer
 ---@field version integer
----@field items LintActions.Item[]
+---@field items LintActions.NormalizedItem[]
 
 return {}

--- a/tests/test_golangci_integration.lua
+++ b/tests/test_golangci_integration.lua
@@ -33,14 +33,14 @@ T['attach()']['uses the default nvim-lint linter and bundled adapter'] = functio
   local wrapped = definition.parser
   integration.attach()
 
-  eq(definition._lint_actions_attached, true)
+  eq(definition._lint_actions_attached, 'golangci-lint')
   eq(definition.parser, wrapped)
 end
 
 T['attach()']['accepts a concrete linter and source override'] = function()
   local definition = linter()
   integration.attach({ linter = definition, source = 'custom-golangci' })
-  eq(definition._lint_actions_attached, true)
+  eq(definition._lint_actions_attached, 'custom-golangci')
 end
 
 T['attach()']['rejects invalid options'] = function()

--- a/tests/test_lint_actions.lua
+++ b/tests/test_lint_actions.lua
@@ -171,6 +171,33 @@ T['publish()']['wraps a list of text edits for the published buffer'] = function
   eq(published.edit.documentChanges[1].edits, { first, second })
 end
 
+T['publish()']['offers an item without a range on every line of the buffer'] = function()
+  local bufnr = helpers.new_buffer('publish-whole-buffer.txt', { 'alpha', 'beta', 'gamma' })
+
+  lint_actions.publish({
+    bufnr = bufnr,
+    source = 'tool',
+    items = { { action = { title = 'Whole buffer' } } },
+  })
+
+  eq(#store.actions(bufnr, helpers.range(0, 0, 0, 0)), 1)
+  eq(#store.actions(bufnr, helpers.range(2, 0, 2, 0)), 1)
+  eq(store.actions(bufnr, helpers.range(9, 0, 9, 0)), {})
+end
+
+T['publish()']['accepts positions without a character'] = function()
+  local bufnr = helpers.new_buffer('publish-line-only.txt', { 'alpha', 'beta' })
+
+  lint_actions.publish({
+    bufnr = bufnr,
+    source = 'tool',
+    items = { { range = { start = { line = 1 }, ['end'] = { line = 1 } }, action = { title = 'Second line' } } },
+  })
+
+  eq(store.actions(bufnr, helpers.range(0, 0, 0, 0)), {})
+  eq(#store.actions(bufnr, helpers.range(1, 0, 1, 0)), 1)
+end
+
 local invalid_publications = {
   {
     'rejects a missing options table',

--- a/tests/test_markdownlint_integration.lua
+++ b/tests/test_markdownlint_integration.lua
@@ -69,8 +69,7 @@ T['attach()']['resolves and configures factory linters by name once'] = function
   eq(lint.linters.markdownlint, factory)
   local definition = factory()
   eq(definition.args, { '--stdin', '--config', 'markdownlint.yaml', '--json' })
-  eq(definition._lint_actions_markdownlint_attached, true)
-  eq(definition._lint_actions_attached, true)
+  eq(definition._lint_actions_attached, 'markdownlint')
 end
 
 T['attach()']['rejects invalid options and linter definitions'] = function()

--- a/tests/test_nvim_lint.lua
+++ b/tests/test_nvim_lint.lua
@@ -90,7 +90,7 @@ T['attach()']['resolves and wraps factory linters by name once'] = function()
   eq(lint.linters.dynamic, factory)
 
   local definition = factory()
-  eq(definition._lint_actions_attached, true)
+  eq(definition._lint_actions_attached, 'tool')
   eq(definition.parser('', -1, vim.fn.getcwd()), diagnostics)
 end
 
@@ -182,8 +182,90 @@ T['attach()']['rejects invalid options, adapters, and linter values'] = function
   expect_error('source', function()
     helpers.call(integration.attach, { linter = {}, adapter = { parse = function() end } })
   end)
+  expect_error('options.configure', function()
+    helpers.call(integration.attach, { linter = {}, adapter = adapter(), configure = 'invalid' })
+  end)
   expect_error('options.linter must be a linter name or table', function()
     helpers.call(integration.attach, { linter = false, adapter = adapter() })
+  end)
+end
+
+T['attach()']['runs configure on the resolved linter before wrapping its parser'] = function()
+  local configured = 0
+  local diagnostics = { { lnum = 0, col = 0, message = 'message', source = 'tool' } }
+  local definition = {
+    parser = function(_, _, _)
+      return {}
+    end,
+  }
+
+  integration.attach({
+    linter = definition,
+    adapter = adapter(),
+    configure = function(linter)
+      configured = configured + 1
+      linter.args = { '--json' }
+      linter.parser = function(_, _, _)
+        return diagnostics
+      end
+    end,
+  })
+
+  -- The wrapped parser must be the one configure installed, not the original.
+  eq(definition.args, { '--json' })
+  eq(definition.parser('', -1, vim.fn.getcwd()), diagnostics)
+
+  integration.attach({
+    linter = definition,
+    adapter = adapter(),
+    configure = function()
+      configured = configured + 1
+    end,
+  })
+  eq(configured, 1)
+end
+
+T['attach()']['runs configure once for a factory linter'] = function()
+  local configured = 0
+  local lint = mock_nvim_lint({
+    dynamic = function()
+      return {
+        parser = function()
+          return {}
+        end,
+      }
+    end,
+  })
+
+  local function configure(linter)
+    configured = configured + 1
+    linter.args = { '--json' }
+  end
+
+  integration.attach({ linter = 'dynamic', adapter = adapter(), configure = configure })
+  integration.attach({ linter = 'dynamic', adapter = adapter(), configure = configure })
+
+  local definition = lint.linters.dynamic()
+  eq(definition.args, { '--json' })
+  eq(definition._lint_actions_attached, 'tool')
+  eq(configured, 1)
+end
+
+T['attach()']['refuses a configure step once another source wrapped the linter'] = function()
+  local definition = {
+    parser = function()
+      return {}
+    end,
+  }
+  integration.attach({ linter = definition, adapter = adapter() })
+
+  expect_error('attach the markdownlint integration before attaching this linter through nvim_lint', function()
+    integration.attach({
+      linter = definition,
+      adapter = adapter(),
+      source = 'markdownlint',
+      configure = function() end,
+    })
   end)
 end
 

--- a/tests/test_providers.lua
+++ b/tests/test_providers.lua
@@ -1,0 +1,297 @@
+local MiniTest = require('mini.test')
+local helpers = require('tests.helpers')
+local lint_actions = require('lint_actions')
+local providers = require('lint_actions.providers')
+local store = require('lint_actions.store')
+
+local eq = helpers.eq
+local expect_error = helpers.expect_error
+
+local function reset()
+  store._reset()
+  providers._reset()
+end
+
+local T = MiniTest.new_set({
+  hooks = { pre_case = reset, post_case = reset },
+})
+
+---@param bufnr integer
+local function wait_for_client(bufnr)
+  return vim.wait(1000, function()
+    local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'lint-actions' })[1]
+    return client ~= nil and client.initialized == true
+  end)
+end
+
+---@param title string
+---@param range? table
+local function item(title, range)
+  return { range = range, action = { title = title, kind = 'quickfix' } }
+end
+
+local function titles(actions)
+  return vim.tbl_map(function(action)
+    return action.title
+  end, actions)
+end
+
+T['register()'] = MiniTest.new_set()
+
+T['register()']['answers requests from current buffer state without republishing'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider.txt'), { 'alpha' })
+
+  lint_actions.register({
+    source = 'line-counter',
+    provide = function(context)
+      return { item(('Lines: %d'):format(vim.api.nvim_buf_line_count(context.bufnr))) }
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Lines: 1' })
+
+  -- The published path would go stale here; a provider recomputes instead.
+  vim.api.nvim_buf_set_lines(bufnr, 1, 1, false, { 'beta', 'gamma' })
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Lines: 3' })
+end
+
+T['register()']['passes the requested range and kind filter to the provider'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-context.txt'), { 'a', 'b' })
+  local seen
+
+  lint_actions.register({
+    source = 'context-recorder',
+    provide = function(context)
+      seen = context
+      return {}
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+
+  helpers.request(bufnr, helpers.range(1, 0, 1, 1), { 'refactor' })
+  eq(seen.bufnr, bufnr)
+  eq(seen.range, helpers.range(1, 0, 1, 1))
+  eq(seen.only, { 'refactor' })
+end
+
+T['register()']['filters provider items by range and kind'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-filter.txt'), { 'a', 'b', 'c' })
+
+  lint_actions.register({
+    source = 'filtered',
+    provide = function()
+      return {
+        { range = helpers.range(0, 0, 0, 1), action = { title = 'First line', kind = 'quickfix' } },
+        { range = helpers.range(2, 0, 2, 1), action = { title = 'Third line', kind = 'refactor.extract' } },
+      }
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'First line' })
+  eq(titles(helpers.request(bufnr, helpers.range(2, 0, 2, 0))), { 'Third line' })
+  eq(titles(helpers.request(bufnr, helpers.range(2, 0, 2, 0), { 'refactor' })), { 'Third line' })
+  eq(titles(helpers.request(bufnr, helpers.range(2, 0, 2, 0), { 'quickfix' })), {})
+end
+
+T['register()']['merges provider and published actions in one sorted response'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-merge.txt'), { 'alpha' })
+
+  lint_actions.publish({
+    bufnr = bufnr,
+    source = 'published',
+    items = { item('B published', helpers.range(0, 0, 0, 5)) },
+  })
+  lint_actions.register({
+    source = 'provided',
+    provide = function()
+      return { item('A provided'), item('C provided') }
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'A provided', 'B published', 'C provided' })
+end
+
+T['register()']['restricts providers by filetype and by buffer'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-gate.txt'), { 'alpha' })
+  vim.bo[bufnr].filetype = 'text'
+
+  lint_actions.register({
+    source = 'lua-only',
+    filetypes = { 'lua' },
+    provide = function()
+      return { item('Lua action') }
+    end,
+  })
+  lint_actions.register({
+    source = 'text-only',
+    filetypes = { 'text' },
+    provide = function()
+      return { item('Text action') }
+    end,
+  })
+  lint_actions.register({
+    source = 'disabled',
+    enabled = function()
+      return false
+    end,
+    provide = function()
+      return { item('Never offered') }
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Text action' })
+
+  vim.bo[bufnr].filetype = 'lua'
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Lua action' })
+end
+
+T['register()']['isolates a failing provider from the rest of the request'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-error.txt'), { 'alpha' })
+  local notifications = {}
+  local notify = vim.notify
+  MiniTest.finally(function()
+    vim.notify = notify
+  end)
+  ---@diagnostic disable-next-line: duplicate-set-field
+  vim.notify = function(message)
+    table.insert(notifications, message)
+  end
+
+  lint_actions.register({
+    source = 'broken',
+    provide = function()
+      error('provider blew up')
+    end,
+  })
+  lint_actions.register({
+    source = 'invalid-items',
+    provide = function()
+      return { { action = { title = 42 } } }
+    end,
+  })
+  lint_actions.register({
+    source = 'healthy',
+    provide = function()
+      return { item('Still offered') }
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Still offered' })
+
+  vim.wait(200, function()
+    return #notifications >= 2
+  end)
+  table.sort(notifications)
+  eq(#notifications, 2)
+  eq(notifications[1]:match('provider broken: .*provider blew up') ~= nil, true)
+  eq(notifications[2], 'lint-actions: provider invalid-items: items[1].action.title must be string, got number')
+end
+
+T['register()']['replaces a provider registered under the same source'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-replace.txt'), { 'alpha' })
+
+  lint_actions.register({
+    source = 'repeated',
+    provide = function()
+      return { item('First registration') }
+    end,
+  })
+  lint_actions.register({
+    source = 'repeated',
+    provide = function()
+      return { item('Second registration') }
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Second registration' })
+end
+
+T['register()']['attaches to files opened after registration'] = function()
+  local path = vim.fs.joinpath(vim.fn.tempname() .. '-provider.txt')
+  vim.fn.writefile({ 'alpha' }, path)
+  MiniTest.finally(function()
+    vim.fn.delete(path)
+  end)
+
+  lint_actions.register({
+    source = 'on-read',
+    provide = function()
+      return { item('Opened action') }
+    end,
+  })
+
+  vim.cmd.edit(path)
+  local bufnr = vim.api.nvim_get_current_buf()
+  MiniTest.finally(function()
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  eq(wait_for_client(bufnr), true)
+  eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Opened action' })
+end
+
+T['register()']['leaves buffers that are not ordinary files alone'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-scratch.txt'), { 'alpha' })
+  vim.bo[bufnr].buftype = 'nofile'
+
+  lint_actions.register({
+    source = 'any-buffer',
+    provide = function()
+      return { item('Never offered') }
+    end,
+  })
+
+  eq(vim.lsp.get_clients({ bufnr = bufnr, name = 'lint-actions' })[1], nil)
+  eq(providers.actions(bufnr, helpers.range(0, 0, 0, 0)), {})
+end
+
+T['register()']['validates its provider'] = function()
+  expect_error('provider must be table, got nil', function()
+    helpers.call(lint_actions.register)
+  end)
+  expect_error('provider.source must be string, got nil', function()
+    helpers.call(lint_actions.register, {})
+  end)
+  expect_error('provider.provide must be function, got nil', function()
+    helpers.call(lint_actions.register, { source = 'tool' })
+  end)
+  expect_error('provider.source must not be empty', function()
+    helpers.call(lint_actions.register, { source = '', provide = function() end })
+  end)
+  expect_error('provider.filetypes must be table, got string', function()
+    helpers.call(lint_actions.register, { source = 'tool', provide = function() end, filetypes = 'lua' })
+  end)
+  expect_error('provider.enabled must be function, got boolean', function()
+    helpers.call(lint_actions.register, { source = 'tool', provide = function() end, enabled = true })
+  end)
+end
+
+T['unregister()'] = MiniTest.new_set()
+
+T['unregister()']['stops a provider from answering'] = function()
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'provider-unregister.txt'), { 'alpha' })
+
+  lint_actions.register({
+    source = 'temporary',
+    provide = function()
+      return { item('Temporary action') }
+    end,
+  })
+  eq(wait_for_client(bufnr), true)
+  eq(#helpers.request(bufnr, helpers.range(0, 0, 0, 0)), 1)
+
+  lint_actions.unregister('temporary')
+  eq(helpers.request(bufnr, helpers.range(0, 0, 0, 0)), {})
+
+  expect_error('source must be string, got nil', function()
+    helpers.call(lint_actions.unregister)
+  end)
+end
+
+return T

--- a/tests/test_server.lua
+++ b/tests/test_server.lua
@@ -59,6 +59,32 @@ T['LSP transport']['publishes native actions, filters them, and rejects stale ba
   eq(vim.api.nvim_buf_get_lines(bufnr, 1, 2, false)[1], 'changed')
 end
 
+T['LSP transport']['returns command-carrying actions unchanged'] = function()
+  local actions = require('lint_actions')
+  local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'command.txt'), { 'alpha' })
+  local range = helpers.range(0, 0, 0, 5)
+  local command = { title = 'Run it', command = 'my-tool.run', arguments = { 'alpha' } }
+
+  actions.publish({
+    bufnr = bufnr,
+    source = 'tool',
+    items = { { range = range, action = { title = 'Run it', kind = 'quickfix', command = command } } },
+  })
+  eq(
+    vim.wait(1000, function()
+      local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'lint-actions' })[1]
+      return client ~= nil and client.initialized == true
+    end),
+    true
+  )
+
+  -- Neovim routes this to `vim.lsp.commands`, so the whole command has to
+  -- survive publication rather than being reduced to its edit.
+  local found = helpers.request(bufnr, range)
+  eq(#found, 1)
+  eq(found[1].command, command)
+end
+
 T['_cmd()'] = MiniTest.new_set()
 
 T['_cmd()']['implements initialization, shutdown, unsupported methods, and one exit'] = function()


### PR DESCRIPTION
Add register() and unregister(), a pull-based counterpart to publish(), and a configure hook on the nvim-lint bridge for integrations that must change a linter's arguments before its parser is wrapped.

Make an item's range optional and accept positions without a character, share item validation and matching between both supply paths, and validate every public entry point through one helper. Document source identity, command-based actions, and the scope of setup().