### PR TITLE
fix: reject stale nvim-lint results

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,13 +54,19 @@ run.
 #### nvim-lint parser wrapping
 
 nvim-lint runs the linter process and publishes the diagnostics. Each linter
-definition has a `parser` function that reads the tool's output. That parser
-is the hook point.
+definition has a `parser` function that reads the tool's output.
+
+The integration wraps nvim-lint's `lint()` entry point once. For attached
+parsers, it captures the buffer's `changedtick` before the run and passes a
+shallow copy of the linter with a parser bound to that run. Other linters pass
+through unchanged. Each process keeps its own snapshot, including when a
+definition is shared by overlapping runs or several buffers.
 
 The integration wraps it. When nvim-lint calls the parser, the integration:
 
 1. calls the original parser to get the diagnostics,
-2. hands both the diagnostics and the same raw output to the adapter,
+2. hands both the diagnostics and the same raw output to the adapter if the
+   buffer has not changed and the run has not been cancelled,
 3. returns the diagnostics to nvim-lint untouched.
 
 Sometimes an adapter needs richer output than the linter produces by default,
@@ -138,7 +144,12 @@ path.
 ## Avoiding stale actions
 
 A published action is valid only for the buffer version from which it was
-computed. Two checks prevent stale edits.
+computed.
+
+The nvim-lint bridge rejects results if the buffer's `changedtick` differs
+from the snapshot captured before the run, even if the buffer was saved again
+while the linter was running. Cancelled runs are also ignored. Neither kind
+of rejected result clears actions that a newer run may have published.
 
 Before returning stored actions, the plugin compares the batch's recorded
 `changedtick` and LSP document version with the current buffer. A mismatch

--- a/doc/lint-actions.txt
+++ b/doc/lint-actions.txt
@@ -83,12 +83,18 @@ nvim-lint runs the linter process and publishes diagnostics. Each linter's
 `parser` function reads the output. lint-actions wraps that parser without
 changing the diagnostics: ~
 
-  1. nvim-lint runs the configured command.
+  1. lint-actions records the buffer's changed tick before nvim-lint runs the
+     configured command.
   2. The linter's parser turns the output into `vim.Diagnostic[]`.
   3. lint-actions hands the same raw output and those diagnostics to the
-     adapter.
+     adapter, unless the buffer changed during the run or the run was cancelled.
   4. The adapter returns code-action items.
   5. The original diagnostics go back to nvim-lint unchanged.
+
+Saving the buffer again while a linter runs does not make its old output fresh.
+Each run retains its own snapshot. Rejected output leaves any actions from a
+newer run alone. The integration installs one wrapper around nvim-lint's
+`lint()` entry point and only binds snapshots for attached parsers.
 
 Any function-based nvim-lint parser can be wrapped this way. To connect one to
 an adapter: >lua

--- a/lua/lint_actions/integrations/nvim_lint.lua
+++ b/lua/lint_actions/integrations/nvim_lint.lua
@@ -2,6 +2,8 @@ local items = require('lint_actions.items')
 
 local M = {}
 local wrapped_factories = setmetatable({}, { __mode = 'k' })
+local wrapped_runners = setmetatable({}, { __mode = 'k' })
+local parser_factories = setmetatable({}, { __mode = 'k' })
 ---@type table<string, LintActions.NvimLintAttachment>
 local attachments = {}
 
@@ -28,6 +30,79 @@ local attachments = {}
 ---@field source? string Overrides the adapter's source.
 ---@field configure? LintActions.NvimLintConfigure Prepares the resolved linter before its parser is wrapped.
 
+---@class LintActions.NvimLintRun
+---@field bufnr integer
+---@field changedtick integer
+---@field process? { cancelled: boolean }
+
+---Bind the snapshot to the process's parser, not the shared linter definition.
+---nvim-lint calls `lint()` for both concrete definitions and resolved factories.
+local function guard_runs()
+  local lint = require('lint')
+  if wrapped_runners[lint.lint] then
+    return
+  end
+  local execute = lint.lint
+  local function guarded(linter, options)
+    local factory = parser_factories[linter.parser]
+    if not factory then
+      return execute(linter, options)
+    end
+
+    local bufnr = vim.api.nvim_get_current_buf()
+    local run = { bufnr = bufnr, changedtick = vim.api.nvim_buf_get_changedtick(bufnr) }
+    local definition = vim.tbl_extend('force', linter, { parser = factory(run) })
+    run.process = execute(definition, options)
+    return run.process
+  end
+  wrapped_runners[guarded] = true
+  lint.lint = guarded
+end
+
+---@param parse LintActions.NvimLintParser
+---@param adapter LintActions.Adapter
+---@param source string
+---@param run? LintActions.NvimLintRun
+---@return LintActions.NvimLintParser
+local function wrap_parser(parse, adapter, source, run)
+  return function(output, bufnr, cwd)
+    local diagnostics = parse(output, bufnr, cwd)
+
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return diagnostics
+    end
+    if run then
+      if
+        bufnr ~= run.bufnr
+        or vim.api.nvim_buf_get_changedtick(bufnr) ~= run.changedtick
+        or (run.process and run.process.cancelled)
+      then
+        -- A newer run may already have published fresh actions. Leave them alone.
+        return diagnostics
+      end
+    end
+    if vim.bo[bufnr].modified then
+      require('lint_actions').clear({ bufnr = bufnr, source = source })
+      return diagnostics
+    end
+
+    local ok, err = pcall(require('lint_actions').ingest, {
+      adapter = adapter,
+      source = source,
+      output = output,
+      bufnr = bufnr,
+      cwd = cwd,
+      diagnostics = diagnostics,
+    })
+    if not ok then
+      vim.schedule(function()
+        vim.notify('lint-actions: ' .. err, vim.log.levels.ERROR)
+      end)
+    end
+    return diagnostics
+  end
+end
+
 ---@param linter LintActions.NvimLintLinter
 ---@param adapter LintActions.Adapter
 ---@param source string
@@ -50,31 +125,9 @@ local function attach(linter, adapter, source, configure)
 
   linter._lint_actions_attached = source
   local parse = linter.parser
-  linter.parser = function(output, bufnr, cwd)
-    local diagnostics = parse(output, bufnr, cwd)
-
-    if not vim.api.nvim_buf_is_valid(bufnr) then
-      return diagnostics
-    end
-    if vim.bo[bufnr].modified then
-      require('lint_actions').clear({ bufnr = bufnr, source = source })
-      return diagnostics
-    end
-
-    local ok, err = pcall(require('lint_actions').ingest, {
-      adapter = adapter,
-      source = source,
-      output = output,
-      bufnr = bufnr,
-      cwd = cwd,
-      diagnostics = diagnostics,
-    })
-    if not ok then
-      vim.schedule(function()
-        vim.notify('lint-actions: ' .. err, vim.log.levels.ERROR)
-      end)
-    end
-    return diagnostics
+  linter.parser = wrap_parser(parse, adapter, source)
+  parser_factories[linter.parser] = function(run)
+    return wrap_parser(parse, adapter, source, run)
   end
 end
 
@@ -121,6 +174,7 @@ function M.attach(options)
     error('options.linter must be a linter name or table')
   end
 
+  guard_runs()
   local name = type(linter_option) == 'string' and linter_option or nil
   attachments[source .. '\0' .. (name or '')] = { source = source, linter = name }
 end

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -6,7 +6,12 @@ M.eq = MiniTest.expect.equality
 
 function M.mock_nvim_lint(linters)
   local previous = package.loaded.lint
-  package.loaded.lint = { linters = linters }
+  package.loaded.lint = {
+    linters = linters,
+    lint = function(definition)
+      return { linter = definition, cancelled = false }
+    end,
+  }
   MiniTest.finally(function()
     package.loaded.lint = previous
   end)

--- a/tests/test_golangci.lua
+++ b/tests/test_golangci.lua
@@ -160,6 +160,7 @@ T['integration.attach()']['uses the default nvim-lint linter and bundled adapter
 end
 
 T['integration.attach()']['accepts a concrete linter and source override'] = function()
+  helpers.mock_nvim_lint({})
   local definition = linter()
   integration.attach({ linter = definition, source = 'custom-golangci' })
   eq(definition._lint_actions_attached, 'custom-golangci')

--- a/tests/test_health.lua
+++ b/tests/test_health.lua
@@ -48,11 +48,7 @@ local function find(reported, pattern)
 end
 
 local function mock_nvim_lint(linters, linters_by_ft)
-  local previous = package.loaded.lint
-  package.loaded.lint = { linters = linters, linters_by_ft = linters_by_ft }
-  MiniTest.finally(function()
-    package.loaded.lint = previous
-  end)
+  helpers.mock_nvim_lint(linters).linters_by_ft = linters_by_ft
 end
 
 local function adapter()

--- a/tests/test_markdownlint.lua
+++ b/tests/test_markdownlint.lua
@@ -181,6 +181,7 @@ T['integration.attach()'] = MiniTest.new_set({
 })
 
 T['integration.attach()']['enables JSON and publishes actions from a concrete linter'] = function()
+  helpers.mock_nvim_lint({})
   local definition = linter()
   integration.attach({ linter = definition })
   local wrapped = definition.parser
@@ -235,6 +236,7 @@ T['integration.attach()']['rejects invalid options and linter definitions'] = fu
 end
 
 T['integration.attach()']['does not duplicate an existing JSON argument'] = function()
+  helpers.mock_nvim_lint({})
   local definition = linter()
   table.insert(definition.args, '--json')
   integration.attach({ linter = definition })

--- a/tests/test_nvim_lint.lua
+++ b/tests/test_nvim_lint.lua
@@ -5,8 +5,23 @@ local store = require('lint_actions.store')
 
 local eq = helpers.eq
 local expect_error = helpers.expect_error
+local previous_lint
 local T = MiniTest.new_set({
-  hooks = { pre_case = store._reset, post_case = store._reset },
+  hooks = {
+    pre_case = function()
+      store._reset()
+      previous_lint = package.loaded.lint
+      package.loaded.lint = {
+        lint = function(definition)
+          return { linter = definition, cancelled = false }
+        end,
+      }
+    end,
+    post_case = function()
+      store._reset()
+      package.loaded.lint = previous_lint
+    end,
+  },
 })
 
 local function adapter(parse)
@@ -258,6 +273,132 @@ T['attach()']['refuses a configure step once another source wrapped the linter']
       configure = function() end,
     })
   end)
+end
+
+T['runs'] = MiniTest.new_set()
+
+T['runs']['rejects output after editing and saving during a run'] = function()
+  local diagnostics = { { message = 'original diagnostic' } }
+  local definition = {
+    parser = function()
+      return diagnostics
+    end,
+  }
+  local lint = helpers.mock_nvim_lint({ tool = definition })
+  local calls = 0
+  integration.attach({
+    linter = 'tool',
+    adapter = adapter(function()
+      calls = calls + 1
+      return { { action = { title = 'outdated fix' } } }
+    end),
+  })
+
+  local bufnr = helpers.new_buffer('nvim-lint-saved.txt', { 'old text' })
+  local process = vim.api.nvim_buf_call(bufnr, function()
+    return lint.lint(definition)
+  end)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'new saved text' })
+  vim.bo[bufnr].modified = false
+
+  eq(process.linter.parser('old output', bufnr, vim.fn.getcwd()), diagnostics)
+  eq(calls, 0)
+  eq(store.actions(bufnr, helpers.range(0, 0, 0, 0)), {})
+end
+
+T['runs']['keeps independent snapshots and ignores cancelled results'] = function()
+  local definition = {
+    parser = function()
+      return {}
+    end,
+  }
+  local lint = helpers.mock_nvim_lint({ tool = definition })
+  integration.attach({
+    linter = 'tool',
+    adapter = adapter(function(context)
+      return { { action = { title = context.output } } }
+    end),
+  })
+  local bufnr = helpers.new_buffer('nvim-lint-overlapping.txt', { 'old' })
+  local first = vim.api.nvim_buf_call(bufnr, function()
+    return lint.lint(definition)
+  end)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'new' })
+  vim.bo[bufnr].modified = false
+  local second = vim.api.nvim_buf_call(bufnr, function()
+    return lint.lint(definition)
+  end)
+  second.linter.parser('fresh fix', bufnr, vim.fn.getcwd())
+  first.linter.parser('stale fix', bufnr, vim.fn.getcwd())
+  local range = helpers.range(0, 0, 0, 0)
+  eq(store.actions(bufnr, range)[1].title, 'fresh fix')
+
+  local cancelled = vim.api.nvim_buf_call(bufnr, function()
+    return lint.lint(definition)
+  end)
+  cancelled.cancelled = true
+  cancelled.linter.parser('cancelled fix', bufnr, vim.fn.getcwd())
+  eq(store.actions(bufnr, range)[1].title, 'fresh fix')
+end
+
+T['runs']['preserves unrelated linters and installs the guard only once'] = function()
+  local definition = {
+    parser = function()
+      return {}
+    end,
+  }
+  local lint = helpers.mock_nvim_lint({ tool = definition })
+  local observed_options
+  lint.lint = function(linter, options)
+    observed_options = options
+    return { linter = linter, cancelled = false }
+  end
+  integration.attach({ linter = 'tool', adapter = adapter() })
+  local guarded = lint.lint
+  integration.attach({ linter = 'tool', adapter = adapter() })
+  eq(lint.lint, guarded)
+  local unrelated = {
+    parser = function()
+      return {}
+    end,
+  }
+  local options = { cwd = '/work', ignore_errors = true }
+  eq(rawequal(lint.lint(unrelated, options).linter, unrelated), true)
+  eq(rawequal(observed_options, options), true)
+end
+
+T['runs']['isolates snapshots for factory linters running in several buffers'] = function()
+  local definition = {
+    parser = function()
+      return {}
+    end,
+  }
+  local lint = helpers.mock_nvim_lint({
+    tool = function()
+      return definition
+    end,
+  })
+  integration.attach({
+    linter = 'tool',
+    adapter = adapter(function(context)
+      return { { action = { title = context.output } } }
+    end),
+  })
+  local first_buf = helpers.new_buffer('nvim-lint-factory-first.txt', { 'old' })
+  local second_buf = helpers.new_buffer('nvim-lint-factory-second.txt', { 'unchanged' })
+  local first = vim.api.nvim_buf_call(first_buf, function()
+    return lint.lint(lint.linters.tool())
+  end)
+  local second = vim.api.nvim_buf_call(second_buf, function()
+    return lint.lint(lint.linters.tool())
+  end)
+  vim.api.nvim_buf_set_lines(first_buf, 0, -1, false, { 'new' })
+  vim.bo[first_buf].modified = false
+  first.linter.parser('old fix', first_buf, vim.fn.getcwd())
+  second.linter.parser('fresh fix', second_buf, vim.fn.getcwd())
+  local range = helpers.range(0, 0, 0, 0)
+  eq(store.actions(first_buf, range), {})
+  eq(store.actions(second_buf, range)[1].title, 'fresh fix')
 end
 
 return T

--- a/tests/test_shellcheck.lua
+++ b/tests/test_shellcheck.lua
@@ -262,6 +262,7 @@ T['integration.attach()'] = MiniTest.new_set({
 })
 
 T['integration.attach()']['publishes actions from a concrete linter'] = function()
+  helpers.mock_nvim_lint({})
   local definition = linter()
   integration.attach({ linter = definition })
   local wrapped = definition.parser


### PR DESCRIPTION
Capture the buffer version before each linter run. Ignore stale and
cancelled results while preserving diagnostics and newer actions. Add
regression coverage for overlapping runs and multiple buffers.
