### PR TITLE
fix: normalize unknown versions in multi-file edits

### DIFF
--- a/lua/lint_actions/compat.lua
+++ b/lua/lint_actions/compat.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+---Treat Lua nil and JSON null as absent, matching Neovim 0.13's vim.isnil().
+---@type fun(value: any): boolean
+---@diagnostic disable-next-line: undefined-field
+M.isnil = vim.isnil or function(value)
+  return value == nil or value == vim.NIL
+end
+
+return M

--- a/lua/lint_actions/items.lua
+++ b/lua/lint_actions/items.lua
@@ -1,4 +1,13 @@
+local compat = require('lint_actions.compat')
+
 local M = {}
+
+---@return any
+local function unknown_document_version()
+  -- Neovim 0.11 treats nil as an unknown version. Neovim 0.12's apply helper
+  -- distinguishes an explicit vim.NIL from a missing field.
+  return vim.fn.has('nvim-0.12') == 1 and vim.NIL or nil
+end
 
 ---Raise a type error. `level` follows `error()` and defaults to the caller of
 ---the function doing the validation, which is right when a public entry point
@@ -93,7 +102,7 @@ local function version_edit(action, uri, version)
     edit.documentChanges = edit.documentChanges or {}
     for edit_uri, edits in pairs(edit.changes) do
       table.insert(edit.documentChanges, {
-        textDocument = { uri = edit_uri, version = edit_uri == uri and version or nil },
+        textDocument = { uri = edit_uri },
         edits = edits,
       })
     end
@@ -101,8 +110,14 @@ local function version_edit(action, uri, version)
   end
 
   for _, change in ipairs(edit.documentChanges or {}) do
-    if change.textDocument and change.textDocument.uri == uri then
-      change.textDocument.version = version
+    local document = change.textDocument
+    if document then
+      if document.uri == uri then
+        document.version = version
+      elseif compat.isnil(document.version) then
+        -- Normalize both representations to the sentinel this Neovim accepts.
+        document.version = unknown_document_version()
+      end
     end
   end
   return action

--- a/tests/test_lint_actions.lua
+++ b/tests/test_lint_actions.lua
@@ -156,6 +156,29 @@ T['publish()']['wraps a text edit for the published buffer'] = function()
   eq(document_edit.edits, { { range = range, newText = 'new' } })
 end
 
+T['publish()']['preserves explicit secondary versions and resource operations'] = function()
+  local bufnr = helpers.new_buffer('publish-secondary-versions.txt', { 'text' })
+  local secondary = helpers.new_buffer('publish-secondary-target.txt', { 'text' })
+  local uri = vim.uri_from_bufnr(secondary)
+  local range = helpers.range(0, 0, 0, 4)
+  local changes = {
+    { textDocument = { uri = uri, version = 42 }, edits = { { range = range, newText = 'new' } } },
+    { textDocument = { uri = uri, version = vim.NIL }, edits = {} },
+    { kind = 'rename', oldUri = uri, newUri = uri .. '.renamed' },
+  }
+  lint_actions.publish({
+    bufnr = bufnr,
+    source = 'tool',
+    items = { { action = { title = 'Update secondary document', edit = { documentChanges = changes } } } },
+  })
+  local published = assert(store.actions(bufnr, range)[1])
+  local normalized = assert(published.edit).documentChanges
+  assert(normalized)
+  eq(normalized[1].textDocument.version, 42)
+  eq(normalized[2].textDocument.version, vim.fn.has('nvim-0.12') == 1 and vim.NIL or nil)
+  eq(normalized[3].kind, 'rename')
+end
+
 T['publish()']['wraps a list of text edits for the published buffer'] = function()
   local bufnr = helpers.new_buffer('publish-text-edits.txt', { 'old text' })
   local first = { range = helpers.range(0, 0, 0, 3), newText = 'new' }
@@ -174,6 +197,40 @@ T['publish()']['wraps a list of text edits for the published buffer'] = function
 
   local published = store.actions(bufnr, first.range)[1]
   eq(published.edit.documentChanges[1].edits, { first, second })
+end
+
+for _, modern in ipairs({ false, true }) do
+  local release = modern and '0.12+' or '0.11'
+  T['publish()']['normalizes missing and explicit null versions for Neovim ' .. release] = function()
+    local bufnr = helpers.new_buffer('versions-' .. release .. '.txt', { 'text' })
+    local secondary_uri = vim.uri_from_fname(vim.fn.getcwd() .. '/secondary.txt')
+    local changes = {
+      { textDocument = { uri = secondary_uri }, edits = {} },
+      { textDocument = { uri = secondary_uri, version = vim.NIL }, edits = {} },
+      { textDocument = { uri = secondary_uri, version = 42 }, edits = {} },
+    }
+    local original = vim.deepcopy(changes)
+    local has = vim.fn.has
+    MiniTest.finally(function()
+      rawset(vim.fn, 'has', has)
+    end)
+    rawset(vim.fn, 'has', function(feature)
+      if feature == 'nvim-0.12' then
+        return modern and 1 or 0
+      end
+      return has(feature)
+    end)
+    local normalized = require('lint_actions.items').normalize({
+      { action = { title = 'Update secondary document', edit = { documentChanges = changes } } },
+    }, bufnr)
+    rawset(vim.fn, 'has', has)
+    local document_changes = assert(assert(normalized[1].action.edit).documentChanges)
+    local expected = modern and vim.NIL or nil
+    eq(document_changes[1].textDocument.version, expected)
+    eq(document_changes[2].textDocument.version, expected)
+    eq(document_changes[3].textDocument.version, 42)
+    eq(changes, original)
+  end
 end
 
 T['publish()']['offers an item without a range on every line of the buffer'] = function()

--- a/tests/test_server.lua
+++ b/tests/test_server.lua
@@ -9,6 +9,49 @@ local T = MiniTest.new_set({
 
 T['LSP transport'] = MiniTest.new_set()
 
+for _, form in ipairs({ 'changes', 'documentChanges' }) do
+  T['LSP transport']['applies multi-file ' .. form .. ' with unknown secondary versions'] = function()
+    local primary = helpers.new_buffer('multi-primary-' .. form .. '.txt', { 'old' })
+    local secondary = helpers.new_buffer('multi-secondary-' .. form .. '.txt', { 'old' })
+    local primary_uri, secondary_uri = vim.uri_from_bufnr(primary), vim.uri_from_bufnr(secondary)
+    local range = helpers.range(0, 0, 0, 3)
+    local edits = { { range = range, newText = 'new' } }
+    local edit = form == 'changes' and { changes = { [primary_uri] = edits, [secondary_uri] = edits } }
+      or {
+        documentChanges = {
+          { textDocument = { uri = secondary_uri }, edits = edits },
+          { textDocument = { uri = primary_uri }, edits = edits },
+        },
+      }
+    local original = vim.deepcopy(edit)
+    require('lint_actions').publish({
+      bufnr = primary,
+      source = 'multi-file',
+      items = { { action = { title = 'Update both files', edit = edit } } },
+    })
+    eq(
+      vim.wait(1000, function()
+        local client = vim.lsp.get_clients({ bufnr = primary, name = 'lint-actions' })[1]
+        return client ~= nil and client.initialized == true
+      end),
+      true
+    )
+
+    local found = helpers.request(primary, range)
+    eq(#found, 1)
+    local version = vim.api.nvim_buf_get_changedtick(primary)
+    vim.lsp.util.apply_workspace_edit(found[1].edit, 'utf-8')
+    eq(vim.api.nvim_buf_get_lines(primary, 0, -1, false), { 'new' })
+    eq(vim.api.nvim_buf_get_lines(secondary, 0, -1, false), { 'new' })
+    for _, change in ipairs(found[1].edit.documentChanges) do
+      local expected = change.textDocument.uri == primary_uri and version
+        or (vim.fn.has('nvim-0.12') == 1 and vim.NIL or nil)
+      eq(change.textDocument.version, expected)
+    end
+    eq(edit, original)
+  end
+end
+
 T['LSP transport']['publishes native actions, filters them, and rejects stale batches'] = function()
   local actions = require('lint_actions')
   local bufnr = helpers.new_buffer(vim.fs.joinpath(vim.fn.getcwd(), 'tests', 'server.txt'), { 'alpha', 'beta' })


### PR DESCRIPTION
Use explicit null versions for secondary documents when unspecified.
Preserve existing versions and resource operations.
Add regression tests covering publication, LSP responses, and edit
application.
