### PR TITLE
fix: discard published actions after buffer renames

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -151,9 +151,10 @@ from the snapshot captured before the run, even if the buffer was saved again
 while the linter was running. Cancelled runs are also ignored. Neither kind
 of rejected result clears actions that a newer run may have published.
 
-Before returning stored actions, the plugin compares the batch's recorded
-`changedtick` and LSP document version with the current buffer. A mismatch
-discards the batch.
+Before returning stored actions, the plugin compares the batch's recorded URI,
+`changedtick`, and LSP document version with the current buffer. A mismatch
+discards the batch, including when a buffer was renamed without changing its
+text. A source must publish again to target the new URI.
 
 Edits for the current buffer are also sent as versioned
 `documentChanges`. If the buffer changes between opening the menu and selecting

--- a/lua/lint_actions/store.lua
+++ b/lua/lint_actions/store.lua
@@ -37,12 +37,13 @@ end
 ---@return lsp.CodeAction[]
 function M.actions(bufnr, range, only)
   local actions = {}
+  local uri = vim.uri_from_bufnr(bufnr)
   local changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
   local version = vim.lsp.util.buf_versions[bufnr]
   local stale = {}
 
   for source, batch in pairs(batches[bufnr] or {}) do
-    if batch.changedtick == changedtick and batch.version == version then
+    if batch.uri == uri and batch.changedtick == changedtick and batch.version == version then
       for _, item in ipairs(batch.items) do
         if items.matches(item, range, only) then
           table.insert(actions, vim.deepcopy(item.action))

--- a/tests/test_server.lua
+++ b/tests/test_server.lua
@@ -128,6 +128,36 @@ T['LSP transport']['returns command-carrying actions unchanged'] = function()
   eq(found[1].command, command)
 end
 
+T['LSP transport']['requires fresh publication after a buffer rename'] = function()
+  local actions = require('lint_actions')
+  local bufnr = helpers.new_buffer('server-before-rename.txt', { 'old' })
+  local range = helpers.range(0, 0, 0, 3)
+  local publication = {
+    bufnr = bufnr,
+    source = 'tool',
+    items = { { action = { title = 'Replace text', edit = { range = range, newText = 'new' } } } },
+  }
+  actions.publish(publication)
+  eq(
+    vim.wait(1000, function()
+      local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'lint-actions' })[1]
+      return client ~= nil and client.initialized == true
+    end),
+    true
+  )
+  eq(#helpers.request(bufnr, range), 1)
+
+  vim.api.nvim_buf_set_name(bufnr, 'server-after-rename.txt')
+  eq(helpers.request(bufnr, range), {})
+
+  actions.publish(publication)
+  local found = helpers.request(bufnr, range)
+  eq(#found, 1)
+  eq(found[1].edit.documentChanges[1].textDocument.uri, vim.uri_from_bufnr(bufnr))
+  vim.lsp.util.apply_workspace_edit(found[1].edit, 'utf-8')
+  eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), { 'new' })
+end
+
 T['_cmd()'] = MiniTest.new_set()
 
 T['_cmd()']['implements initialization, shutdown, unsupported methods, and one exit'] = function()

--- a/tests/test_store.lua
+++ b/tests/test_store.lua
@@ -66,6 +66,23 @@ T['actions()']['returns copies that callers can mutate'] = function()
   eq(store.actions(bufnr, range)[1].title, 'Original')
 end
 
+T['actions()']['discards renamed batches even when the buffer text is unchanged'] = function()
+  local bufnr = helpers.new_buffer('store-before-rename.txt', { 'text' })
+  local original_name = vim.api.nvim_buf_get_name(bufnr)
+  local range = helpers.range(0, 0, 0, 4)
+  local batch = helpers.batch(bufnr, 'tool', 'Old action', range)
+  store.publish(batch)
+
+  vim.api.nvim_buf_set_name(bufnr, 'store-after-rename.txt')
+  eq(vim.api.nvim_buf_get_changedtick(bufnr), batch.changedtick)
+  eq(vim.lsp.util.buf_versions[bufnr], batch.version)
+  eq(store.actions(bufnr, range), {})
+
+  -- Once discarded, renaming back must not resurrect the old batch.
+  vim.api.nvim_buf_set_name(bufnr, original_name)
+  eq(store.actions(bufnr, range), {})
+end
+
 T['clear()'] = MiniTest.new_set()
 
 T['clear()']['clears one source or the whole buffer and tolerates missing state'] = function()


### PR DESCRIPTION
Include the buffer URI in freshness checks. Add regression coverage for
renames and fresh publications.
