### PR TITLE
fix: isolate provider action processing errors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,8 +90,9 @@ code actions, the plugin calls `provide` with the current buffer state and uses
 the returned items.
 
 `provide` runs while Neovim waits for the response, so it must be synchronous
-and quick. If it raises an error, the plugin reports it and skips that provider;
-the rest of the request is unaffected.
+and quick. Errors during execution, validation, normalization, or filtering are
+reported and discard that provider's entire result. Other providers and
+published actions still answer the request.
 
 Both routes return the same item shape and use the same range and action-kind
 matching.

--- a/doc/lint-actions.txt
+++ b/doc/lint-actions.txt
@@ -301,9 +301,9 @@ integrations only and rejects unknown names. Call |lint_actions.publish()| or
     synchronous and quick. A slow provider delays the menu. Publish fixes
     produced by an external process instead.
 
-    If `provide` raises an error, it is reported with |vim.notify()| and that
-    provider is skipped. Other providers and published actions still answer
-    the same request.
+    Errors while running `provide` or validating, normalizing, or filtering its
+    results are reported with |vim.notify()|. That provider's entire result is
+    skipped. Other providers and published actions still answer the request.
 
     Registering a provider attaches the in-process client to the ordinary
     file buffers it applies to (`buftype` empty), including ones already

--- a/lua/lint_actions/providers.lua
+++ b/lua/lint_actions/providers.lua
@@ -44,21 +44,24 @@ end
 ---Run one provider, keeping its failures out of the rest of the request.
 ---@param provider LintActions.Provider
 ---@param context LintActions.ProviderContext
----@return LintActions.NormalizedItem[]? items
+---@return lsp.CodeAction[]? actions
 ---@return string? err
 local function collect(provider, context)
-  local ok, produced = pcall(provider.provide, context)
+  local ok, actions = pcall(function()
+    local candidates = provider.provide(context) or {}
+    items.validate(candidates)
+    local matched = {}
+    for _, item in ipairs(items.normalize(candidates, context.bufnr)) do
+      if items.matches(item, context.range, context.only) then
+        table.insert(matched, item.action)
+      end
+    end
+    return matched
+  end)
   if not ok then
-    return nil, tostring(produced)
+    return nil, tostring(actions)
   end
-
-  ---@type LintActions.Item[]
-  local candidates = produced or {}
-  local valid, invalid = pcall(items.validate, candidates)
-  if not valid then
-    return nil, tostring(invalid)
-  end
-  return items.normalize(candidates, context.bufnr)
+  return actions
 end
 
 ---@param bufnr integer
@@ -123,11 +126,7 @@ function M.actions(bufnr, range, only)
       if not produced then
         report(source, err or 'provider failed')
       else
-        for _, item in ipairs(produced) do
-          if items.matches(item, range, only) then
-            table.insert(actions, item.action)
-          end
-        end
+        vim.list_extend(actions, produced)
       end
     end
   end

--- a/tests/test_providers.lua
+++ b/tests/test_providers.lua
@@ -212,6 +212,49 @@ T['register()']['replaces a provider registered under the same source'] = functi
   eq(titles(helpers.request(bufnr, helpers.range(0, 0, 0, 0))), { 'Second registration' })
 end
 
+for _, field in ipairs({ 'edit', 'kind' }) do
+  T['register()']['isolates malformed ' .. field .. ' fields throughout action processing'] = function()
+    local bufnr = helpers.new_buffer('provider-malformed-' .. field .. '.txt', { 'text' })
+    local notifications = {}
+    local notify = vim.notify
+    MiniTest.finally(function()
+      vim.notify = notify
+    end)
+    ---@diagnostic disable-next-line: duplicate-set-field
+    vim.notify = function(message)
+      table.insert(notifications, message)
+    end
+
+    lint_actions.register({
+      source = 'a-malformed',
+      provide = function()
+        local malformed = item('Malformed action')
+        rawset(malformed.action, field, field == 'edit' and 'invalid' or 42)
+        return { item('Partial result'), malformed }
+      end,
+    })
+    lint_actions.register({
+      source = 'z-healthy',
+      provide = function()
+        return { item('Healthy result') }
+      end,
+    })
+    lint_actions.publish({ bufnr = bufnr, source = 'published', items = { item('Published result') } })
+    eq(wait_for_client(bufnr), true)
+
+    local result = helpers.request(bufnr, helpers.range(0, 0, 0, 0), { 'quickfix' })
+    eq(titles(result), { 'Healthy result', 'Published result' })
+    eq(
+      vim.wait(200, function()
+        return #notifications > 0
+      end),
+      true
+    )
+    eq(#notifications, 1)
+    eq(notifications[1]:find('lint-actions: provider a-malformed:', 1, true) ~= nil, true)
+  end
+end
+
 T['register()']['attaches to files opened after registration'] = function()
   local path = vim.fs.joinpath(vim.fn.tempname() .. '-provider.txt')
   vim.fn.writefile({ 'alpha' }, path)


### PR DESCRIPTION
Protect the complete provider processing path. Add regression tests
confirming malformed edits and action kinds preserve healthy providers
and published actions.
