### PR TITLE
fix: reject malformed golangci suggestions atomically

### DIFF
--- a/doc/lint-actions-golangci.txt
+++ b/doc/lint-actions-golangci.txt
@@ -64,6 +64,11 @@ Every usable `SuggestedFix` for the current file becomes a `quickfix` action.
 The title uses the suggested-fix message when there is one, and names the
 linter that found the problem.
 
+The entire suggestion is skipped if any replacement has invalid Base64 or
+an invalid byte range. Offsets must be integers within the buffer, with the end
+at or after the start. Valid alternative suggestions remain available. Empty
+and null replacement text represent deletions.
+
 Edits go out as versioned workspace edits. They go stale as soon as the buffer
 changes, and pickers that show diffs can preview them.
 

--- a/lua/lint_actions/adapters/golangci.lua
+++ b/lua/lint_actions/adapters/golangci.lua
@@ -1,3 +1,4 @@
+local compat = require('lint_actions.compat')
 local offsets = require('lint_actions.offsets')
 local paths = require('lint_actions.paths')
 
@@ -47,28 +48,46 @@ local function issue_range(issue, text, ranges)
 end
 
 local function decode(value)
-  if type(value) ~= 'string' then
+  -- A nil Go []byte is encoded as JSON null and represents a deletion.
+  if compat.isnil(value) then
     return ''
   end
+  if type(value) ~= 'string' then
+    return nil
+  end
   local ok, decoded = pcall(vim.base64.decode, value)
-  return ok and decoded or ''
+  return ok and decoded or nil
+end
+
+local function valid_offset(value, text)
+  return type(value) == 'number' and value == math.floor(value) and value >= 0 and value <= #text
 end
 
 local function text_edits(fix, text)
   local edits = {}
-  if type(fix) ~= 'table' or type(fix.TextEdits) ~= 'table' then
+  if type(fix) ~= 'table' or type(fix.TextEdits) ~= 'table' or not vim.islist(fix.TextEdits) then
     return edits
   end
   for _, edit in ipairs(fix.TextEdits) do
-    if type(edit) == 'table' and type(edit.Pos) == 'number' and type(edit.End) == 'number' then
-      table.insert(edits, {
-        range = {
-          start = offsets.to_position(text, edit.Pos, 'utf-8'),
-          ['end'] = offsets.to_position(text, edit.End, 'utf-8'),
-        },
-        newText = decode(edit.NewText),
-      })
+    if
+      type(edit) ~= 'table'
+      or not valid_offset(edit.Pos, text)
+      or not valid_offset(edit.End, text)
+      or edit.End < edit.Pos
+    then
+      return {}
     end
+    local new_text = decode(edit.NewText)
+    if new_text == nil then
+      return {}
+    end
+    table.insert(edits, {
+      range = {
+        start = offsets.to_position(text, edit.Pos, 'utf-8'),
+        ['end'] = offsets.to_position(text, edit.End, 'utf-8'),
+      },
+      newText = new_text,
+    })
   end
   return edits
 end

--- a/tests/test_golangci.lua
+++ b/tests/test_golangci.lua
@@ -145,6 +145,77 @@ T['parse()']['handles representative golangci-lint v2 output'] = function()
   eq(by_title['"404" can be replaced by http.StatusNotFound [usestdlibvars]'][1].newText, 'http.StatusNotFound')
 end
 
+local malformed_edits = {
+  { name = 'invalid Base64', edit = { Pos = 0, End = 1, NewText = '!!!' } },
+  { name = 'non-string replacement', edit = { Pos = 0, End = 1, NewText = 42 } },
+  { name = 'non-table edit', edit = false },
+  { name = 'missing start', edit = { End = 1, NewText = '' } },
+  { name = 'negative start', edit = { Pos = -1, End = 1, NewText = '' } },
+  { name = 'fractional start', edit = { Pos = 0.5, End = 1, NewText = '' } },
+  { name = 'fractional end', edit = { Pos = 0, End = 1.5, NewText = '' } },
+  { name = 'reversed range', edit = { Pos = 2, End = 1, NewText = '' } },
+  { name = 'end outside the buffer', edit = { Pos = 0, End = 99, NewText = '' } },
+}
+
+for _, case in ipairs(malformed_edits) do
+  T['parse()']['rejects an entire suggestion containing ' .. case.name] = function()
+    local bufnr = helpers.new_buffer('golangci-invalid-fix.go', { 'abc' })
+    local output = vim.json.encode({
+      Issues = {
+        {
+          Pos = { Filename = vim.api.nvim_buf_get_name(bufnr) },
+          SuggestedFixes = {
+            {
+              Message = 'Broken suggestion',
+              TextEdits = {
+                { Pos = 3, End = 3, NewText = vim.base64.encode('!') },
+                case.edit,
+              },
+            },
+            {
+              Message = 'Valid alternative',
+              TextEdits = {
+                { Pos = 0, End = 3, NewText = vim.base64.encode('xyz') },
+              },
+            },
+          },
+        },
+      },
+    })
+    local parsed = adapter.parse({ bufnr = bufnr, output = output, cwd = vim.fn.getcwd() })
+    eq(#parsed, 1)
+    eq(parsed[1].action.title, 'Valid alternative')
+    vim.lsp.util.apply_text_edits(parsed[1].action.edit, bufnr, 'utf-8')
+    eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), { 'xyz' })
+  end
+end
+
+T['parse()']['preserves empty and null deletions and insertions at EOF'] = function()
+  local bufnr = helpers.new_buffer('golangci-valid-boundaries.go', { 'abc' })
+  vim.bo[bufnr].endofline = false
+  local output = vim.json.encode({
+    Issues = {
+      {
+        Pos = { Filename = vim.api.nvim_buf_get_name(bufnr) },
+        SuggestedFixes = {
+          {
+            TextEdits = {
+              { Pos = 0, End = 1, NewText = '' },
+              { Pos = 1, End = 2, NewText = vim.NIL },
+              { Pos = 3, End = 3, NewText = vim.base64.encode('!') },
+            },
+          },
+        },
+      },
+    },
+  })
+  local parsed = adapter.parse({ bufnr = bufnr, output = output, cwd = vim.fn.getcwd() })
+  eq(#parsed, 1)
+  eq(#parsed[1].action.edit, 3)
+  vim.lsp.util.apply_text_edits(parsed[1].action.edit, bufnr, 'utf-8')
+  eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), { 'c!' })
+end
+
 T['integration.attach()'] = MiniTest.new_set()
 
 T['integration.attach()']['uses the default nvim-lint linter and bundled adapter'] = function()


### PR DESCRIPTION
Reject suggestions containing invalid Base64, malformed edits, or
invalid byte ranges. Preserve valid deletions and add regression coverage.
