### PR TITLE
refactor/sort actions once

### DIFF
--- a/lua/lint_actions/store.lua
+++ b/lua/lint_actions/store.lua
@@ -31,6 +31,7 @@ function M.clear(bufnr, source)
 end
 
 ---Return fresh actions matching an LSP range and optional kind filter.
+---Ordering is handled by the server after merging provider actions.
 ---@param bufnr integer
 ---@param range lsp.Range
 ---@param only? lsp.CodeActionKind[]
@@ -58,7 +59,7 @@ function M.actions(bufnr, range, only)
     M.clear(bufnr, source)
   end
 
-  return items.sort(actions)
+  return actions
 end
 
 ---Reset all state. Intended for tests.

--- a/tests/test_sarif.lua
+++ b/tests/test_sarif.lua
@@ -60,6 +60,90 @@ local function apply(action)
   end
 end
 
+local function ingest(bufnr, run)
+  require('lint_actions').ingest({
+    adapter = adapter,
+    output = output(run),
+    bufnr = bufnr,
+    cwd = vim.fn.getcwd(),
+  })
+  eq(
+    vim.wait(1000, function()
+      local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'lint-actions' })[1]
+      return client ~= nil and client.initialized == true
+    end),
+    true
+  )
+end
+
+T['action pipeline'] = MiniTest.new_set({
+  hooks = { pre_case = require('lint_actions.store')._reset, post_case = require('lint_actions.store')._reset },
+})
+
+T['action pipeline']['ingests, filters, sorts, and applies Unicode alternatives'] = function()
+  local name = 'sarif-pipeline-unicode.lua'
+  local bufnr = helpers.new_buffer(name, { '-- example', '😀 bad' })
+  local edit_region = region(2, 4, 2, 7)
+  ingest(bufnr, {
+    columnKind = 'utf16CodeUnits',
+    results = {
+      {
+        locations = { location(name, edit_region) },
+        fixes = {
+          fix('Use good.', { change(name, { replacement(edit_region, 'good') }) }),
+          fix('Use best.', { change(name, { replacement(edit_region, 'best') }) }),
+        },
+      },
+    },
+  })
+  local range = helpers.range(1, 0, 1, 0)
+  eq(helpers.request(bufnr, helpers.range(0, 0, 0, 0)), {})
+  eq(helpers.request(bufnr, range, { 'refactor' }), {})
+  local found = helpers.request(bufnr, range, { 'quickfix' })
+  eq(
+    vim.tbl_map(function(action)
+      return action.title
+    end, found),
+    { 'Use best.', 'Use good.' }
+  )
+  local changes = found[1].edit.documentChanges
+  eq(found[1].edit.changes, nil)
+  eq(changes[1].textDocument.version, vim.api.nvim_buf_get_changedtick(bufnr))
+  vim.lsp.util.apply_workspace_edit(found[1].edit, 'utf-8')
+  eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), { '-- example', '😀 best' })
+  eq(helpers.request(bufnr, range), {})
+end
+
+for _, update_primary in ipairs({ false, true }) do
+  local target = update_primary and 'both artifacts' or 'only a secondary artifact'
+  T['action pipeline']['ingests and applies a fix targeting ' .. target] = function()
+    local primary_name, secondary_name = 'sarif-pipeline-primary.lua', 'sarif-pipeline-secondary.lua'
+    local primary = helpers.new_buffer(primary_name, { 'one' })
+    local secondary = helpers.new_buffer(secondary_name, { 'two' })
+    local edit_region = region(1, 1, 1, 4)
+    local changes = { change(secondary_name, { replacement(edit_region, 'TWO') }) }
+    if update_primary then
+      table.insert(changes, change(primary_name, { replacement(edit_region, 'ONE') }))
+    end
+    ingest(primary, {
+      columnKind = 'unicodeCodePoints',
+      results = {
+        {
+          locations = { location(primary_name, edit_region) },
+          fixes = { fix('Update artifacts.', changes) },
+        },
+      },
+    })
+    local found = helpers.request(primary, helpers.range(0, 0, 0, 0))
+    eq(#found, 1)
+    eq(found[1].edit.changes, nil)
+    eq(#found[1].edit.documentChanges, update_primary and 2 or 1)
+    vim.lsp.util.apply_workspace_edit(found[1].edit, 'utf-8')
+    eq(vim.api.nvim_buf_get_lines(primary, 0, -1, false), { update_primary and 'ONE' or 'one' })
+    eq(vim.api.nvim_buf_get_lines(secondary, 0, -1, false), { 'TWO' })
+  end
+end
+
 T['parse()'] = MiniTest.new_set()
 
 T['parse()']['creates a quick fix from a described SARIF fix'] = function()

--- a/tests/test_store.lua
+++ b/tests/test_store.lua
@@ -17,12 +17,11 @@ T['publish()']['keeps sources independent and replaces one source batch'] = func
   store.publish(helpers.batch(bufnr, 'two', 'other', range))
   store.publish(helpers.batch(bufnr, 'one', 'new', range))
 
-  eq(
-    vim.tbl_map(function(action)
-      return action.title
-    end, store.actions(bufnr, range)),
-    { 'new', 'other' }
-  )
+  local titles = vim.tbl_map(function(action)
+    return action.title
+  end, store.actions(bufnr, range))
+  table.sort(titles)
+  eq(titles, { 'new', 'other' })
 end
 
 T['actions()'] = MiniTest.new_set()


### PR DESCRIPTION
- **refactor: sort actions only at the response boundary**
- **test: cover the complete SARIF action pipeline**
