### PR TITLE
perf: defer golangci-lint initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ They are also available in Neovim as `:help lint-actions-golangci`,
 `:help lint-actions-markdownlint`, `:help lint-actions-shellcheck`, and
 `:help lint-actions-sarif`.
 
+The golangci-lint integration defers loading nvim-lint's linter definition
+until its first run. This keeps golangci-lint's version and Go module discovery
+out of Neovim startup.
+
 The nvim-lint bridge also supports custom adapters. It preserves the
 diagnostics from any function-based parser and passes the same raw output to
 the adapter. If the adapter requires another output format, update the linter's

--- a/doc/lint-actions-golangci.txt
+++ b/doc/lint-actions-golangci.txt
@@ -32,6 +32,10 @@ as you normally would: >lua
 <
 Trigger nvim-lint from a command, a mapping, or an autocmd.
 
+The default named linter is loaded lazily. Enabling this integration therefore
+does not run nvim-lint's golangci-lint version or Go module discovery during
+Neovim startup; those happen when golangci-lint first runs.
+
 Actions are only kept when the buffer is unmodified. golangci-lint reads the
 file from disk, so its fixes describe the saved file. Applying them to a
 buffer you have since edited would put the text in the wrong place.
@@ -55,6 +59,9 @@ under: >lua
 <
 `require('lint_actions.integrations.golangci').attach()` accepts the same
 options for direct use.
+
+Set `defer = false` to resolve a named linter immediately. Concrete linter
+definitions are always attached immediately because they are already loaded.
 
 To write an adapter for a different tool, see |lint-actions-nvim-lint|.
 

--- a/doc/lint-actions.txt
+++ b/doc/lint-actions.txt
@@ -104,10 +104,14 @@ an adapter: >lua
     adapter = require('my_adapter'),
     source = 'optional-source-override',
     configure = optional_function,
+    defer = false,
   })
 <
 `linter` takes a registered nvim-lint name or a linter definition. The adapter
-must have a `source` field and a `parse(context)` function.
+must have a `source` field and a `parse(context)` function. Set `defer = true`
+to avoid loading a named built-in linter until nvim-lint first runs it.
+User-defined linters already stored in `lint.linters` and concrete definitions
+are attached immediately.
 
 On its own, `attach()` does not touch the linter's command or arguments. Use
 `configure` for that.

--- a/lua/lint_actions/integrations/golangci.lua
+++ b/lua/lint_actions/integrations/golangci.lua
@@ -7,6 +7,7 @@ local M = {}
 ---@class LintActions.GolangciOptions
 ---@field linter? string|LintActions.NvimLintLinter Defaults to `golangcilint`.
 ---@field source? string Overrides the adapter's source.
+---@field defer? boolean Defers loading a named linter until its first run. Defaults to true.
 
 ---Publish golangci-lint SuggestedFixes from nvim-lint's existing output.
 ---Calling this function more than once is safe.
@@ -25,11 +26,17 @@ function M.attach(options)
   if source == nil then
     source = adapter.source
   end
+  local defer = options.defer
+  if defer == nil then
+    defer = true
+  end
+  items.expect(defer, 'boolean', 'options.defer')
 
   return nvim_lint.attach({
     linter = linter,
     adapter = adapter,
     source = source,
+    defer = defer,
   })
 end
 

--- a/lua/lint_actions/integrations/nvim_lint.lua
+++ b/lua/lint_actions/integrations/nvim_lint.lua
@@ -29,6 +29,7 @@ local attachments = {}
 ---@field adapter LintActions.Adapter
 ---@field source? string Overrides the adapter's source.
 ---@field configure? LintActions.NvimLintConfigure Prepares the resolved linter before its parser is wrapped.
+---@field defer? boolean Defers loading a named built-in linter until its first run.
 
 ---@class LintActions.NvimLintRun
 ---@field bufnr integer
@@ -131,6 +132,68 @@ local function attach(linter, adapter, source, configure)
   end
 end
 
+---@param lint table
+---@param name string
+---@param linter LintActions.NvimLintEntry
+---@param adapter LintActions.Adapter
+---@param source string
+---@param configure? LintActions.NvimLintConfigure
+local function attach_entry(lint, name, linter, adapter, source, configure)
+  if type(linter) == 'function' then
+    if wrapped_factories[linter] then
+      return
+    end
+    local factory = function()
+      local definition = linter()
+      items.expect(definition, 'table', 'linter definition', 0)
+      attach(definition, adapter, source, configure)
+      return definition
+    end
+    wrapped_factories[factory] = true
+    lint.linters[name] = factory
+  elseif type(linter) == 'table' then
+    attach(linter, adapter, source, configure)
+  else
+    error(('unknown nvim-lint linter: %s'):format(name))
+  end
+end
+
+---@param lint table
+---@param name string
+---@param adapter LintActions.Adapter
+---@param source string
+---@param configure? LintActions.NvimLintConfigure
+local function attach_deferred(lint, name, adapter, source, configure)
+  -- User-defined linters are stored directly. Wrapping one cannot trigger
+  -- nvim-lint's lazy module loader, so there is no work to defer.
+  local existing = rawget(lint.linters, name)
+  if existing ~= nil then
+    attach_entry(lint, name, existing, adapter, source, configure)
+    return
+  end
+
+  local loaded
+  local factory = function()
+    if loaded == nil then
+      local ok, linter = pcall(require, 'lint.linters.' .. name)
+      if not ok then
+        error(('unknown nvim-lint linter: %s'):format(name), 0)
+      end
+      loaded = linter
+    end
+
+    local definition = loaded
+    if type(definition) == 'function' then
+      definition = definition()
+    end
+    items.expect(definition, 'table', 'linter definition', 0)
+    attach(definition, adapter, source, configure)
+    return definition
+  end
+  wrapped_factories[factory] = true
+  lint.linters[name] = factory
+end
+
 ---Wrap an nvim-lint parser and publish fixes from the same process output.
 ---The parser's diagnostics and return value are preserved.
 ---@param options LintActions.NvimLintOptions
@@ -141,6 +204,9 @@ function M.attach(options)
   if options.configure ~= nil then
     items.expect(options.configure, 'function', 'options.configure')
   end
+  if options.defer ~= nil then
+    items.expect(options.defer, 'boolean', 'options.defer')
+  end
 
   local source = options.source
   if source == nil then
@@ -150,23 +216,10 @@ function M.attach(options)
   local linter_option = options.linter
   if type(linter_option) == 'string' then
     local lint = require('lint')
-    local linter = lint.linters[linter_option]
-    if type(linter) == 'function' then
-      if wrapped_factories[linter] then
-        return
-      end
-      local factory = function()
-        local definition = linter()
-        items.expect(definition, 'table', 'linter definition', 0)
-        attach(definition, options.adapter, source, options.configure)
-        return definition
-      end
-      wrapped_factories[factory] = true
-      lint.linters[linter_option] = factory
-    elseif type(linter) == 'table' then
-      attach(linter, options.adapter, source, options.configure)
+    if options.defer then
+      attach_deferred(lint, linter_option, options.adapter, source, options.configure)
     else
-      error(('unknown nvim-lint linter: %s'):format(linter_option))
+      attach_entry(lint, linter_option, lint.linters[linter_option], options.adapter, source, options.configure)
     end
   elseif type(linter_option) == 'table' then
     attach(linter_option, options.adapter, source, options.configure)

--- a/tests/integration/bridges/test_golangci.lua
+++ b/tests/integration/bridges/test_golangci.lua
@@ -26,6 +26,21 @@ T['integration.attach()']['uses the default nvim-lint linter and bundled adapter
   eq(definition.parser, wrapped)
 end
 
+T['integration.attach()']['defers loading the default nvim-lint linter'] = function()
+  local lookups = 0
+  local lint = helpers.mock_nvim_lint(setmetatable({}, {
+    __index = function()
+      lookups = lookups + 1
+      return linter()
+    end,
+  }))
+
+  integration.attach()
+
+  eq(lookups, 0)
+  eq(type(rawget(lint.linters, 'golangcilint')), 'function')
+end
+
 T['integration.attach()']['accepts a concrete linter and source override'] = function()
   helpers.mock_nvim_lint({})
   local definition = linter()
@@ -42,6 +57,9 @@ T['integration.attach()']['rejects invalid options'] = function()
   end)
   expect_error('source', function()
     helpers.call(integration.attach, { linter = linter(), source = false })
+  end)
+  expect_error('options.defer', function()
+    helpers.call(integration.attach, { defer = 'invalid' })
   end)
 end
 

--- a/tests/integration/bridges/test_nvim_lint.lua
+++ b/tests/integration/bridges/test_nvim_lint.lua
@@ -85,6 +85,46 @@ T['attach()']['resolves and wraps factory linters by name once'] = function()
   eq(definition.parser('', -1, vim.fn.getcwd()), diagnostics)
 end
 
+T['attach()']['defers loading a named built-in linter until its factory runs'] = function()
+  local module = 'lint.linters.lint_actions_deferred_test'
+  local previous_preload = package.preload[module]
+  local previous_loaded = package.loaded[module]
+  package.loaded[module] = nil
+
+  local loads = 0
+  package.preload[module] = function()
+    loads = loads + 1
+    return {
+      parser = function()
+        return {}
+      end,
+    }
+  end
+  MiniTest.finally(function()
+    package.preload[module] = previous_preload
+    package.loaded[module] = previous_loaded
+  end)
+
+  local lint = helpers.mock_nvim_lint(setmetatable({}, {
+    __index = function(_, name)
+      return require('lint.linters.' .. name)
+    end,
+  }))
+  integration.attach({
+    linter = 'lint_actions_deferred_test',
+    adapter = adapter(),
+    defer = true,
+  })
+
+  eq(loads, 0)
+  local factory = rawget(lint.linters, 'lint_actions_deferred_test')
+  eq(type(factory), 'function')
+
+  local definition = factory()
+  eq(loads, 1)
+  eq(definition._lint_actions_attached, 'tool')
+end
+
 T['attach()']['does not ingest an invalid buffer'] = function()
   helpers.mock_nvim_lint({})
   local adapter_calls = 0
@@ -179,6 +219,9 @@ T['attach()']['rejects invalid options, adapters, and linter values'] = function
   end)
   expect_error('options.configure', function()
     helpers.call(integration.attach, { linter = {}, adapter = adapter(), configure = 'invalid' })
+  end)
+  expect_error('options.defer', function()
+    helpers.call(integration.attach, { linter = {}, adapter = adapter(), defer = 'invalid' })
   end)
   expect_error('options.linter must be a linter name or table', function()
     helpers.call(integration.attach, { linter = false, adapter = adapter() })


### PR DESCRIPTION
Defer loading nvim-lint’s golangci-lint definition until its first run.
This avoids synchronous version and Go module discovery during Neovim
startup while preserving existing configuration and behavior.
